### PR TITLE
Feature: tags

### DIFF
--- a/src/models/collections.model.js
+++ b/src/models/collections.model.js
@@ -3,7 +3,7 @@ class Collection {
     uid = '',
     name = '',
     description = '',
-    labels = ['bucket'],
+    labels = ['bucket', 'collection'],
     creationDate = new Date(),
     lastModifiedDate = new Date(),
   } = {}, complete = false) {

--- a/src/models/tags.model.js
+++ b/src/models/tags.model.js
@@ -1,0 +1,42 @@
+class Tag {
+  constructor({
+    uid = '',
+    name = '',
+    labels = ['bucket', 'tag'],
+    creationDate = new Date(),
+    lastModifiedDate = new Date(),
+    articles = [],
+  } = {}, complete = false) {
+    this.uid = String(uid);
+    this.labels = labels;
+    this.name = String(name);
+
+    if (creationDate instanceof Date) {
+      this.creationDate = creationDate;
+    } else {
+      this.creationDate = new Date(creationDate);
+    }
+
+    if (lastModifiedDate instanceof Date) {
+      this.lastModifiedDate = lastModifiedDate;
+    } else {
+      this.lastModifiedDate = new Date(lastModifiedDate);
+    }
+
+    if (complete) {
+      this.articles = articles;
+    }
+  }
+}
+
+module.exports = function () { // app) {
+  // const config = app.get('sequelize');
+  // const issue = model(app.get('sequelizeClient'), {});
+  //
+  // return {
+  //   sequelize: issue,
+  // };
+};
+
+// module.exports.model = model;
+module.exports.Model = Tag;

--- a/src/services/articles-tags/articles-tags.hooks.js
+++ b/src/services/articles-tags/articles-tags.hooks.js
@@ -1,6 +1,5 @@
 const { authenticate } = require('@feathersjs/authentication').hooks;
 const { validate, REGEX_UID } = require('../../hooks/params');
-const { queryWithCurrentUser } = require('feathers-authentication-hooks');
 
 module.exports = {
   before: {
@@ -8,24 +7,29 @@ module.exports = {
     find: [],
     get: [],
     create: [
-      queryWithCurrentUser({
-        idField: 'uid',
-        as: 'user__uid',
-      }),
       validate({
-        article__uid: {
+        article_uid: {
           required: true,
           regex: REGEX_UID,
         },
-        tag__uid: {
+        tag: {
           required: true,
-          regex: REGEX_UID,
+          max_length: 100,
+          // check unicode table order: https://unicode-table.com/en/
+          regex: /^[0-9A-zÀ-ÿ\s,:;?!]+$/,
         },
-      }),
+      }, 'POST'),
     ],
     update: [],
     patch: [],
-    remove: [],
+    remove: [
+      validate({
+        tag_uid: {
+          required: true,
+          regex: REGEX_UID,
+        },
+      }, 'GET'),
+    ],
   },
 
   after: {

--- a/src/services/articles-tags/articles-tags.queries.cyp
+++ b/src/services/articles-tags/articles-tags.queries.cyp
@@ -1,6 +1,48 @@
 // name: merge
+// create tag if it doesn't exist.
+MATCH (u:user {uid:{user_uid}})-[:subscribed_to]->(pro:Project {uid: {Project}})
+WITH u
+MATCH (art:article {uid:{article_uid}})
+WHERE art.Project = {Project}
+WITH u, art
+LIMIT 1
+MERGE (tag:bucket:tag {uid:{tag_uid}})
+  ON CREATE SET
+    tag.creation_time = {_exec_time},
+    tag.creation_date = {_exec_date},
+    tag.name = {tag_name}
+SET
+  tag.last_modified_time = {_exec_time},
+  tag.last_modified_date = {_exec_date}
+WITH u, art, tag
+MERGE (u)-[r1:is_creator_of]->(tag)
+WITH art, tag
+MERGE (tag)-[r2:describes]->(art)
+  ON CREATE SET
+    r2.creation_time = {_exec_time},
+    r2.creation_date = {_exec_date}
+WITH tag
+MATCH (tag)-[r:describes]->()
+WITH tag, count(r) as count_articles
+SET tag.count_articles = count_articles
+RETURN tag
+
+// name: remove
+//
+MATCH (u:user {uid: {user_uid}})-[:subscribed_to]->(pro:Project {uid: {Project}})
+WITH u
+MATCH (u)-[:is_creator_of]->(tag:bucket:tag {uid: {tag_uid}})-[r:describes]->(art:article {uid: {article_uid}})
+DELETE r
+WITH tag
+MATCH (tag)-[r:describes]->()
+WITH tag, count(r) as count_articles
+SET tag.count_articles = count_articles
+RETURN tag
+
+
+// name: __merge
 // create action item and add relationships with articles
-MATCH (u:user {uid:{user__uid}}), (tag:tag {uid:{tag__uid}}), (art:article {uid:{article__uid}})
+MATCH (u:user {uid:{user__uid}}), (tag:bucket:tag {uid:{tag__uid}}), (art:article {uid:{article__uid}})
 WITH u, art, tag
 MERGE (tag)-[r:describes]->(art)
 ON CREATE SET

--- a/src/services/articles/articles.class.js
+++ b/src/services/articles/articles.class.js
@@ -2,13 +2,13 @@ const Neo4jService = require('../neo4j.service').Service;
 const solr = require('../../solr');
 const { NotFound } = require('@feathersjs/errors');
 const article = require('../../models/articles.model');
+const Tag = require('../../models/tags.model').Model;
 
 class Service extends Neo4jService {
   constructor(options) {
     super(options);
     this.solr = solr.client(options.app.get('solr'));
   }
-
 
   async find(params) {
     let fl = article.ARTICLE_SOLR_FL_LITE;
@@ -86,7 +86,12 @@ class Service extends Neo4jService {
     if (uids.length > 1) {
       return results[0].response.docs;
     }
-    return results[0].response.docs[0];
+    // enrich with neo4j results
+    return {
+      ...results[0].response.docs[0],
+      // add tags
+      tags: results[1] ? results[1].tags.map(d => new Tag(d)) : [],
+    };
 
     // // if params findall was true or when multiple ids are given, results[1] is an array.
     // if (Array.isArray(results[1].data) && results[1].data.length) {

--- a/src/services/articles/articles.queries.cyp
+++ b/src/services/articles/articles.queries.cyp
@@ -112,32 +112,27 @@ RETURN art, _related_tags, _related_buckets
 MATCH (art:article {uid:{uid}})
 WHERE art.Project = {Project}
 WITH art
-OPTIONAL MATCH (art)-[:appears_at]->(pag:page)
-WITH art, collect(pag) as _related_pages
-OPTIONAL MATCH (art)-[r:appears_at]->(pag:page)
-WITH art, _related_pages, pag, CASE WHEN r IS NOT NULL THEN collect({
-  regions: properties(r).regions,
-  article_uid: art.uid,
-  page_uid: pag.uid
-}) ELSE [] END as _related_regions
-WITH art, _related_pages, _related_regions
 OPTIONAL MATCH (art)-[:appears_at]->(pag:page)-[:belongs_to]->(iss:issue)
-WITH art, _related_pages, _related_regions, head(collect(iss)) as _related_issue
-OPTIONAL MATCH (tag:tag)-[:describes]->(art)
-WITH art, _related_pages, _related_regions, _related_issue, collect(tag) as _related_tags
+WITH art, head(collect(iss)) as _related_issue
 OPTIONAL MATCH (news:newspaper {uid:art.newspaper_uid})
-WITH art, _related_pages, _related_regions, _related_issue, _related_tags, news as _related_newspaper
+WITH art, _related_issue, news as _related_newspaper
 
 {{^_exec_user_uid}}
-  WITH art, _related_pages, _related_regions, _related_issue, _related_tags, _related_newspaper, [] as _related_buckets
+  WITH art, _related_issue, _related_newspaper, [] as _related_collections, [] as _related_tags
 {{/_exec_user_uid}}
 
 {{#_exec_user_uid}}
   OPTIONAL MATCH (u:user {uid: {_exec_user_uid}})-[:is_creator_of]->(buc:bucket)-[:contains]->(art)
-  WITH art, _related_pages, _related_regions, _related_issue, _related_tags, _related_newspaper, collect(buc) as _related_buckets
+  WITH art, _related_issue, _related_newspaper,
+      collect(buc) as _related_collections
+
+  OPTIONAL MATCH (u:user {uid: {_exec_user_uid}})-[:is_creator_of]->(tag:tag)-[:describes]->(art)
+  WITH art, _related_issue, _related_newspaper, _related_collections,
+      collect(tag) as _related_tags
+
 {{/_exec_user_uid}}
 
-RETURN  art, _related_pages, _related_regions, _related_issue, _related_tags, _related_newspaper, _related_buckets
+RETURN  art, _related_issue, _related_newspaper, _related_collections, _related_tags
 
 
 // name: merge

--- a/src/services/neo4j.service.js
+++ b/src/services/neo4j.service.js
@@ -12,7 +12,7 @@ const errors = require('@feathersjs/errors');
 class Neo4jService {
   constructor(options) {
     this.options = options || {};
-    this.config = options.config;
+    this.config = options.config || options.app.get('neo4j');
     this.name = options.name;
     // camelcase in options name
     // this.options.path = this.options.name.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase()
@@ -59,6 +59,7 @@ class Neo4jService {
    */
   _finalizeCreateOne(res) {
     let data;
+
     if (res.records.length) {
       data = neo4jRecordMapper(res.records[0]);
     }

--- a/src/services/neo4j.utils.js
+++ b/src/services/neo4j.utils.js
@@ -104,7 +104,7 @@ const neo4jFieldMapper = (field) => {
   if (field.constructor.name === 'Path') { return neo4jPathMapper(field); }
   if (field.constructor.name === 'Array') { return field.map(neo4jFieldMapper); }
   if (field.constructor.name === 'Number') { return field; }
-
+  if (field.constructor.name === 'Relationship') { return neo4jRelationshipMapper(field); }
   debug('neo4jFieldMapper: unknown neo4j constructor:', field.constructor.name);
   return null;
 };
@@ -203,6 +203,12 @@ const neo4jNodeMapper = (node) => {
   };
 };
 
+const neo4jRelationshipMapper = relationship => ({
+  relationship: {
+    type: relationship.type,
+    ...relationship.properties,
+  },
+});
 
 const neo4jPathSegmentMapper = segment => ({
   start: neo4jNodeMapper(segment.start),

--- a/src/services/tags/tags.class.js
+++ b/src/services/tags/tags.class.js
@@ -1,14 +1,37 @@
 /* eslint-disable no-unused-vars */
+const debug = require('debug')('impresso/services:articles-tags');
 const Neo4jService = require('../neo4j.service').Service;
+const shash = require('short-hash');
 
 class Service extends Neo4jService {
+  async find(params) {
+    return [];
+  }
+
+  async get(id, params) {
+    return {
+      id, text: `A new message with ID: ${id}!`,
+    };
+  }
+
   async create(data, params) {
     if (Array.isArray(data)) {
-      const results = await Promise.all(data.map(current => this.create(current)));
-      return results;
+      return Promise.all(data.map(current => this.create(current, params)));
     }
 
     return data;
+  }
+
+  async update(id, data, params) {
+    return data;
+  }
+
+  async patch(id, data, params) {
+    return data;
+  }
+
+  async remove(id, params) {
+    return { id };
   }
 }
 

--- a/src/services/tags/tags.hooks.js
+++ b/src/services/tags/tags.hooks.js
@@ -3,9 +3,7 @@ const { validate, queryWithCommonParams, utils } = require('../../hooks/params')
 
 module.exports = {
   before: {
-    all: [
-
-    ],
+    all: [],
     find: [
       validate({
         q: {

--- a/src/services/tags/tags.queries.cyp
+++ b/src/services/tags/tags.queries.cyp
@@ -3,6 +3,7 @@
 
 // name: find
 //
+// 
 MATCH (pro:Project {uid: {Project}})
 WITH COALESCE(pro.count_tags, -1) as _total
 {{#q}}

--- a/src/services/tags/tags.service.js
+++ b/src/services/tags/tags.service.js
@@ -8,13 +8,13 @@ module.exports = function (app) {
   const options = {
     name: 'tags',
     paginate,
-    config: app.get('neo4j'),
+    app,
   };
 
   // Initialize our service with any options it requires
   app.use('/tags', createService(options));
 
-  // Get our initialized service so that we can register hooks and filters
+  // Get our initialized service so that we can register hooks
   const service = app.service('tags');
 
   service.hooks(hooks);

--- a/src/services/users/users.class.js
+++ b/src/services/users/users.class.js
@@ -38,13 +38,12 @@ class Service extends Neo4jService {
     const result = this._run(this.queries.create, {
       ...data.sanitized,
       ...user,
-    }).then((res) => {
-      console.log(res.records, res);
-      return res.records.map(neo4jRecordMapper).map(d => ({
+    }).then(res =>
+      // console.log(res.records, res);
+      res.records.map(neo4jRecordMapper).map(d => ({
         ...d,
         id: d.id,
-      }));
-    });
+      })));
 
     return result;
     // return data;

--- a/test/services/articles-tags.test.js
+++ b/test/services/articles-tags.test.js
@@ -1,9 +1,79 @@
 const assert = require('assert');
 const app = require('../../src/app');
+const { generateUser, removeGeneratedUser } = require('./utils');
+/*
+./node_modules/.bin/eslint \
+src/services/utils.js src/models src/services/articles-tags \
+test/services/articles-tags.test.js --fix &&
+DEBUG=impresso* mocha test/services/articles-tags.test.js
 
-describe('\'articles-tags\' service', () => {
+./node_modules/.bin/eslint \
+src/services/utils.js src/models src/services/articles-tags \
+test/services/articles-tags.test.js --fix &&
+mocha test/services/articles-tags.test.js
+*/
+describe('\'articles-tags\' service', function () {
+  this.timeout(10000);
+
+  const service = app.service('articles-tags');
+  let user = {
+    username: 'guest-test-2',
+    password: 'Apaaiiai87!!',
+    email: 'guest-test-2@impresso-project.ch',
+  };
+
+  let tag;
+
   it('registered the service', () => {
-    const service = app.service('articles-tags');
     assert.ok(service, 'Registered the service');
+  });
+
+  it('setup the test', async () => {
+    user = await generateUser(user);
+    assert.ok(user.uid);
+  });
+
+  //
+  it('attach a tag to our test article', async () => {
+    const results = await service.create({
+      article_uid: 'GDL-1902-05-12-a-i0012',
+      tag: 'brave new world',
+    }, {
+      user,
+    });
+
+    tag = results.data;
+    assert.equal(results.info._stats.relationshipsCreated, 2);
+    assert.equal(results.data.name, 'brave new world');
+    assert.ok(results.data.labels);
+  });
+
+  it('check that the tag is in the taglist', async () => {
+    const resultAuth = await app.service('articles').get('GDL-1902-05-12-a-i0012', {
+      user,
+    });
+    assert.ok(resultAuth.labels);
+    // Does contain the tag
+    assert.equal(resultAuth.tags[0].uid, tag.uid);
+
+    const result = await app.service('articles').get('GDL-1902-05-12-a-i0012');
+    // SHOULD not contain the tag
+    assert.equal(result.tags.length, 0);
+  });
+
+  it('remove the tag attached to our beloved article', async () => {
+    // console.log(tag);
+    const results = await service.remove('GDL-1902-05-12-a-i0012', {
+      user,
+      query: {
+        tag_uid: tag.uid,
+      },
+    });
+    assert.equal(results.info._stats.relationshipsDeleted, 1);
+    // console.log(results);
+  });
+
+  it('remove setup', async () => {
+    await removeGeneratedUser(user);
   });
 });

--- a/test/services/utils.js
+++ b/test/services/utils.js
@@ -1,0 +1,21 @@
+const app = require('../../src/app');
+
+const removeGeneratedUser = async (user) => {
+  await app.service('users').remove(user.username, {
+    user: {
+      is_staff: true,
+    },
+  });
+};
+
+const generateUser = async (user) => {
+  await removeGeneratedUser(user);
+  const result = await app.service('users').create(user);
+  return result[0];
+};
+
+
+module.exports = {
+  generateUser,
+  removeGeneratedUser,
+};


### PR DESCRIPTION
Refactoring of the `articles-tags` endpoint, with `create` and `remove` methods only.
The create method takes an `article_uid` and a free tag as data parameters. 

Behind the scenes, the middle layer looks for the related `tag.uid` or creates a new tag otherwise.. 

```javascript
const result = await service.create({
      article_uid: 'GDL-1902-05-12-a-i0012',
      tag: 'brave new world',
    }, {
      user,
    });
````
In this case, the response.data will contain the  tag (created or modified)
Tags being strictly *personal*, the tag uid will be a concatenation of the user uid who performed the query followed by a short hash version of the chosen tag name.
