### PR TITLE
add basic stats per newspaper 

### DIFF
--- a/scripts/update-newspapers.js
+++ b/scripts/update-newspapers.js
@@ -5,8 +5,9 @@ const debug = require('debug')('impresso/scripts:update-data');
 const config = require('@feathersjs/configuration')()();
 const sequelizeClient = require('../src/sequelize').client(config.sequelize);
 const solrClient = require('../src/solr').client(config.solr);
-const Newspaper = require(`../src/models/newspapers.model`);
-const Topic = require(`../src/models/topics.model`);
+
+const Newspaper = require('../src/models/newspapers.model');
+const Issue = require('../src/models/issues.model');
 
 
 debug('start!');
@@ -18,34 +19,64 @@ async function waterfall() {
     .then(results => results.map(d => d.toJSON()))
     .then(results => lodash.keyBy(results, 'acronym'));
 
-  // pages per newspaper per year
-  sequelizeClient.query(
-    `SELECT COUNT(p.id) as count, iss.year, n.id FROM impresso_dev.pages p
-    JOIN impresso_dev.issues as iss ON iss.id = p.issue_id
-    JOIN impresso_dev.newspapers as n ON n.id = p.newspaper_id
-    GROUP BY iss.year, n.id LIMIT 1000;`, {
+  // get total pages per newspapers
+  await sequelizeClient.query(`SELECT COUNT(*) as countPages, p.newspaper_id as uid
+       FROM impresso_dev.pages AS p
+     GROUP BY p.newspaper_id`, {
     type: sequelizeClient.QueryTypes.SELECT,
-  }).then(res => {
-    console.log(res);
-  }).catch(err => {
+  }).then((results) => {
+    results.forEach((d) => {
+      newspapers[d.uid].countPages = d.countPages;
+    });
+  }).catch((err) => {
     console.log(err);
   });
 
+  // get (real) articles!
+  await solrClient.findAll({
+    q: 'filter(content_length_i:[1 TO *])',
+    limit: 0,
+    skip: 0,
+    fl: 'id',
+    facets: JSON.stringify({
+      newspaper: {
+        type: 'terms',
+        field: 'meta_journal_s',
+        mincount: 1,
+        limit: 1000,
+        numBuckets: true,
+      },
+    }),
+  }).then((results) => {
+    results.facets.newspaper.buckets.forEach((d) => {
+      newspapers[d.val].countArticles = d.count;
+    });
+  });
+
+  // get firstIssue and lastIssue
+  await sequelizeClient.query(`SELECT n.id as uid, MIN(iss.id) as firstIssue, MAX(iss.id) as lastIssue, COUNT(iss.id) as countIssues
+       FROM issues as iss
+       JOIN newspapers as n ON n.id = iss.newspaper_id
+     GROUP BY n.id`, {
+    type: sequelizeClient.QueryTypes.SELECT,
+  }).then((results) => {
+    results.forEach((d) => {
+      newspapers[d.uid].firstIssue = new Issue({ uid: d.firstIssue });
+      newspapers[d.uid].lastIssue = new Issue({ uid: d.lastIssue });
+      newspapers[d.uid].countIssues = d.countIssues;
+    });
+  }).catch((err) => {
+    console.log(err);
+  });
 
   debug('saving', Object.keys(newspapers).length, 'newspapers...');
 
-
-
   fs.writeFileSync('./src/data/newspapers.json', JSON.stringify(newspapers));
   debug('success, saved ./src/data/newspapers.js');
-
-
   debug('count newspaper issues, pages');
-
-
 }
 
-waterfall().then((res) => {
+waterfall().then(() => {
   debug('done, exit.'); // prints 60 after 2 seconds.
   process.exit();
 }).catch((err) => {

--- a/src/models/newspapers.model.js
+++ b/src/models/newspapers.model.js
@@ -30,10 +30,12 @@ class Newspaper {
 
     const indexed = newspapersIndex.getValue(this.uid);
 
-    if (!name.length && indexed) {
+    if (indexed) {
       this.name = indexed.name;
       this.endYear = parseInt(indexed.endYear, 10);
       this.startYear = parseInt(indexed.startYear, 10);
+      this.firstIssue = indexed.firstIssue;
+      this.lastIssue = indexed.lastIssue;
       this.languages = indexed.languages;
       this.countArticles = parseInt(indexed.countArticles, 10);
       this.countIssues = parseInt(indexed.countIssues, 10);


### PR DESCRIPTION
Fixes #119 
preload data with a specific script instead of using the view.
Execute script with:
`NODE_ENV=production DEBUG=imp* npm run update-newspapers`

Add following property to each newspaper:
````json
{
  "name": "Gazette de Lausanne",
  ...
  "firstIssue": {
    "uid": "GDL-1798-02-01-a",
    "cover": "",
    "labels": [ "issue" ],
    "date": "1798-02-01T00:00:00.000Z"
  },
  "lastIssue": {
    "uid": "GDL-1997-12-31-a",
    "cover": "",
    "labels": [ "issue" ],
    "date": "1997-12-31T00:00:00.000Z"
  },
  "countArticles": 2132389,
  "countIssues": 51012,
  "countPages": 323221,
  ...
}