### PR TITLE
Feature: enable newspapers filters and order by for /newspapers service

### DIFF
--- a/src/models/newspapers.model.js
+++ b/src/models/newspapers.model.js
@@ -72,10 +72,10 @@ class Newspaper {
         type: Sequelize.SMALLINT,
         field: 'end',
       },
-      // countIssues: {
-      //   type: Sequelize.INTEGER,
-      //   field: 'number_issues',
-      // },
+      countIssues: {
+        type: Sequelize.INTEGER,
+        field: 'number_issues',
+      },
     }, {
       tableName: 'np_timespan_v',
     });

--- a/src/services/newspapers/newspapers.class.js
+++ b/src/services/newspapers/newspapers.class.js
@@ -27,7 +27,7 @@ class Service {
     return this.SequelizeService.get(id, {
       scope: 'get',
       where,
-    });
+    }).then(d => d.toJSON());
   }
 
   async find(params) {
@@ -40,6 +40,19 @@ class Service {
         { name: params.query.q },
         { uid: params.query.q },
       ];
+    }
+
+    if (params.query.filters && params.query.filters.length) {
+      where[Op.and] = [];
+      if (params.query.filters.some(d => d.type === 'included')) {
+        where[Op.and].push({
+          '$stats.start$': { [Op.not]: null },
+        });
+      } else if (params.query.filters.some(d => d.type === 'excluded')) {
+        where[Op.and].push({
+          '$stats.start$': { [Op.is]: null },
+        });
+      }
     }
 
     return this.SequelizeService.find({

--- a/src/services/newspapers/newspapers.hooks.js
+++ b/src/services/newspapers/newspapers.hooks.js
@@ -28,6 +28,7 @@ module.exports = {
             'endYear',
             'firstIssue', '-firstIssue',
             'lastIssue', '-lastIssue',
+            'countIssues', '-countIssues',
           ],
           defaultValue: 'name',
           transform: d => utils.translate(d, {
@@ -41,6 +42,8 @@ module.exports = {
             '-firstIssue': [['stats', 'startYear', 'DESC']],
             lastIssue: [['stats', 'endYear', 'ASC']],
             '-lastIssue': [['stats', 'endYear', 'DESC']],
+            countIssues: [['stats', 'number_issues', 'ASC']],
+            '-countIssues': [['stats', 'number_issues', 'DESC']],
           }),
         },
       }),

--- a/src/services/newspapers/newspapers.hooks.js
+++ b/src/services/newspapers/newspapers.hooks.js
@@ -2,6 +2,7 @@ const {
   queryWithCommonParams, validate, validateEach, utils,
 } = require('../../hooks/params');
 const { checkCachedContents, returnCachedContents, saveResultsInCache } = require('../../hooks/redis');
+const { validateWithSchema } = require('../../hooks/schema');
 
 module.exports = {
   before: {
@@ -11,6 +12,7 @@ module.exports = {
       }),
     ],
     find: [
+      validateWithSchema('services/newspapers/schema/find/query.json', 'params.query'),
       validate({
         q: {
           required: false,

--- a/src/services/newspapers/newspapers.hooks.js
+++ b/src/services/newspapers/newspapers.hooks.js
@@ -1,4 +1,6 @@
-const { queryWithCommonParams, validate, utils } = require('../../hooks/params');
+const {
+  queryWithCommonParams, validate, validateEach, utils,
+} = require('../../hooks/params');
 const { checkCachedContents, returnCachedContents, saveResultsInCache } = require('../../hooks/redis');
 
 module.exports = {
@@ -16,7 +18,15 @@ module.exports = {
           transform: d => utils.toSequelizeLike(d),
         },
         order_by: {
-          choices: ['-name', 'name', '-startYear', 'startYear', '-endYear', 'endYear'],
+          choices: [
+            '-name',
+            'name',
+            '-startYear',
+            'startYear', '-endYear',
+            'endYear',
+            'firstIssue', '-firstIssue',
+            'lastIssue', '-lastIssue',
+          ],
           defaultValue: 'name',
           transform: d => utils.translate(d, {
             name: [['name', 'ASC']],
@@ -25,8 +35,20 @@ module.exports = {
             '-startYear': [['startYear', 'DESC']],
             endYear: [['endYear', 'ASC']],
             '-endYear': [['endYear', 'DESC']],
+            firstIssue: [['stats', 'startYear', 'ASC']],
+            '-firstIssue': [['stats', 'startYear', 'DESC']],
+            lastIssue: [['stats', 'endYear', 'ASC']],
+            '-lastIssue': [['stats', 'endYear', 'DESC']],
           }),
         },
+      }),
+      validateEach('filters', {
+        type: {
+          choices: ['included', 'excluded'],
+          required: true,
+        },
+      }, {
+        required: false,
       }),
       queryWithCommonParams(),
     ],

--- a/src/services/newspapers/schema/find/query.json
+++ b/src/services/newspapers/schema/find/query.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/impresso/impresso-middle-layer/tree/master/src/services/newspapers/schema/find/query.json",
+  "description": "Query params validation for /newspapers/find",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "filters": {
+      "type": "array",
+      "items": {
+        "$ref": "https://github.com/impresso/impresso-middle-layer/tree/master/src/schema/search/filter.json"
+      }
+    },
+    "order_by": {
+      "type": "string",
+      "description": "Order intersection items by this value"
+    },
+    "q": {
+      "type": "string",
+      "description": "Newspaper containing q"
+    },
+    "limit": {
+      "$ref": "https://github.com/impresso/impresso-middle-layer/tree/master/src/schema/common/pagination.json#/properties/limit"
+    },
+    "offset": {
+      "$ref": "https://github.com/impresso/impresso-middle-layer/tree/master/src/schema/common/pagination.json#/properties/offset"
+    },
+    "skip": {
+      "$ref": "https://github.com/impresso/impresso-middle-layer/tree/master/src/schema/common/pagination.json#/properties/skip"
+    },
+    "page": {
+      "$ref": "https://github.com/impresso/impresso-middle-layer/tree/master/src/schema/common/pagination.json#/properties/page"
+    }
+  }
+}

--- a/src/util/json.js
+++ b/src/util/json.js
@@ -7,6 +7,8 @@ ajv.addSchema(require('../schema/search/filter.json'));
 
 ajv.addSchema(require('../services/search-queries-comparison/schema/post/payload.json'));
 ajv.addSchema(require('../services/search-queries-comparison/schema/post/response.json'));
+ajv.addSchema(require('../services/newspapers/schema/find/query.json'));
+
 
 const BaseSchemaURI = 'https://github.com/impresso/impresso-middle-layer/tree/master/src';
 

--- a/test/services/newspapers.test.js
+++ b/test/services/newspapers.test.js
@@ -64,6 +64,15 @@ describe('\'newspapers\' service', function () {
     }
   });
 
+  it('get newspapers, order by countIssues desc', async () => {
+    const results = await service.find({
+      query: {
+        order_by: '-countIssues',
+      },
+    });
+    assert.ok(results.data[0].countIssues > results.data[1].countIssues, 'the biggest newspaper first');
+  });
+
   it('get newspapers!', async () => {
     const results = await service.find({
       query: {},

--- a/test/services/newspapers.test.js
+++ b/test/services/newspapers.test.js
@@ -34,7 +34,18 @@ describe('\'newspapers\' service', function () {
     assert.strictEqual(result.included, false);
   });
 
-  it.only('get only included newspaper', async () => {
+  it('get newspapers, should fail because of JSON schema', async () => {
+    const result = await service.find({
+      query: {
+        included: true,
+      },
+    }).catch(({ code }) => {
+      assert.strictEqual(code, 400);
+    });
+    assert.strictEqual(result, undefined);
+  });
+
+  it('get only included newspaper', async () => {
     const results = await service.find({
       query: {
         order_by: 'lastIssue',


### PR DESCRIPTION
Using a special view, we can filter out non included newspapers.
We can sort by number of issues, last issue and first issue, too.