### PR TITLE
Respect Solr index when converting filters to Solr queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,27 +123,27 @@
       "integrity": "sha512-dVsAFPYsSgi63XI0iNXCGPEDrZTDcdSz6GUtYFsWuoj+LaksyYO3cvZcpJLiQFvPSCjbZX1HDqCpECTvIuAm8A==",
       "dev": true,
       "requires": {
-	"@feathersjs/tools": "^0.1.7",
-	"commander": "^4.0.0",
+        "@feathersjs/tools": "^0.1.7",
+        "commander": "^4.0.0",
         "generator-feathers": "4.2.0",
-	"generator-feathers-plugin": "1.0.1",
-	"semver": "^7.0.0",
-	"update-notifier": "^4.0.0",
-	"yeoman-environment": "^2.4.0"
+        "generator-feathers-plugin": "1.0.1",
+        "semver": "^7.0.0",
+        "update-notifier": "^4.0.0",
+        "yeoman-environment": "^2.4.0"
       },
       "dependencies": {
-	"commander": {
+        "commander": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-	  "dev": true
-	},
-	"semver": {
+          "dev": true
+        },
+        "semver": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
           "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
-	  "dev": true
-	}
+          "dev": true
+        }
       }
     },
     "@feathersjs/commons": {
@@ -240,134 +240,134 @@
       "integrity": "sha1-d5xEOU+6/uXF1K/UyxWu8W9YHxA=",
       "dev": true,
       "requires": {
-	"async": "^1.5.0",
-	"babel-plugin-transform-flow-strip-types": "^6.8.0",
-	"babel-preset-es2015": "^6.9.0",
-	"babel-preset-stage-1": "^6.5.0",
-	"babel-register": "^6.9.0",
-	"babylon": "^6.8.1",
-	"colors": "^1.1.2",
-	"es6-promise": "^3.0.0",
-	"flow-parser": "^0.*",
-	"lodash": "^4.13.1",
-	"micromatch": "^2.3.7",
-	"node-dir": "0.1.8",
-	"nomnom": "^1.8.1",
-	"recast": "^0.11.11",
-	"temp": "^0.8.1",
-	"write-file-atomic": "^1.2.0"
+        "async": "^1.5.0",
+        "babel-plugin-transform-flow-strip-types": "^6.8.0",
+        "babel-preset-es2015": "^6.9.0",
+        "babel-preset-stage-1": "^6.5.0",
+        "babel-register": "^6.9.0",
+        "babylon": "^6.8.1",
+        "colors": "^1.1.2",
+        "es6-promise": "^3.0.0",
+        "flow-parser": "^0.*",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.7",
+        "node-dir": "0.1.8",
+        "nomnom": "^1.8.1",
+        "recast": "^0.11.11",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^1.2.0"
       },
       "dependencies": {
-	"arr-diff": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-	  "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-	  "dev": true,
-	  "requires": {
-	    "arr-flatten": "^1.0.1"
-	  }
-	},
-	"array-unique": {
-	  "version": "0.2.1",
-	  "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-	  "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-	  "dev": true
-	},
-	"async": {
-	  "version": "1.5.2",
-	  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-	  "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-	  "dev": true
-	},
-	"braces": {
-	  "version": "1.8.5",
-	  "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-	  "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-	  "dev": true,
-	  "requires": {
-	    "expand-range": "^1.8.1",
-	    "preserve": "^0.2.0",
-	    "repeat-element": "^1.1.2"
-	  }
-	},
-	"colors": {
-	  "version": "1.4.0",
-	  "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-	  "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-	  "dev": true
-	},
-	"expand-brackets": {
-	  "version": "0.1.5",
-	  "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-	  "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-	  "dev": true,
-	  "requires": {
-	    "is-posix-bracket": "^0.1.0"
-	  }
-	},
-	"extglob": {
-	  "version": "0.3.2",
-	  "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-	  "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-	  "dev": true,
-	  "requires": {
-	    "is-extglob": "^1.0.0"
-	  }
-	},
-	"is-extglob": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-	  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-	  "dev": true
-	},
-	"is-glob": {
-	  "version": "2.0.1",
-	  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-	  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-	  "dev": true,
-	  "requires": {
-	    "is-extglob": "^1.0.0"
-	  }
-	},
-	"kind-of": {
-	  "version": "3.2.2",
-	  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-	  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-	  "dev": true,
-	  "requires": {
-	    "is-buffer": "^1.1.5"
-	  }
-	},
-	"micromatch": {
-	  "version": "2.3.11",
-	  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-	  "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-	  "dev": true,
-	  "requires": {
-	    "arr-diff": "^2.0.0",
-	    "array-unique": "^0.2.1",
-	    "braces": "^1.8.2",
-	    "expand-brackets": "^0.1.4",
-	    "extglob": "^0.3.1",
-	    "filename-regex": "^2.0.0",
-	    "is-extglob": "^1.0.0",
-	    "is-glob": "^2.0.1",
-	    "kind-of": "^3.0.2",
-	    "normalize-path": "^2.0.1",
-	    "object.omit": "^2.0.0",
-	    "parse-glob": "^3.0.4",
-	    "regex-cache": "^0.4.2"
-	  }
-	},
-	"normalize-path": {
-	  "version": "2.1.1",
-	  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-	  "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-	  "dev": true,
-	  "requires": {
-	    "remove-trailing-separator": "^1.0.1"
-	  }
-	}
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "dev": true,
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "dev": true,
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "@feathersjs/socketio": {
@@ -398,10 +398,10 @@
       "integrity": "sha512-pwpMjC+cfWLp27h9jzV8trk1gJW5kP3miuyK+0I78mVrCS9fqlHL4IOtw8z6mMmipGW2uB4xWZzlD3a0Ft68YQ==",
       "dev": true,
       "requires": {
-	"@feathersjs/jscodeshift": "^0.5.0",
-	"debug": "^3.1.0",
-	"fs-extra": "^5.0.0",
-	"npm-programmatic": "0.0.9"
+        "@feathersjs/jscodeshift": "^0.5.0",
+        "debug": "^3.1.0",
+        "fs-extra": "^5.0.0",
+        "npm-programmatic": "0.0.9"
       }
     },
     "@feathersjs/transport-commons": {
@@ -432,8 +432,8 @@
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
-	"call-me-maybe": "^1.0.1",
-	"glob-to-regexp": "^0.3.0"
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
       }
     },
     "@nodelib/fs.stat": {
@@ -454,7 +454,7 @@
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "dev": true,
       "requires": {
-	"defer-to-connect": "^1.0.1"
+        "defer-to-connect": "^1.0.1"
       }
     },
     "@types/body-parser": {
@@ -511,9 +511,9 @@
       "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
       "dev": true,
       "requires": {
-	"@types/events": "*",
-	"@types/minimatch": "*",
-	"@types/node": "*"
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
       }
     },
     "@types/jsonwebtoken": {
@@ -619,41 +619,41 @@
       "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "dev": true,
       "requires": {
-	"string-width": "^3.0.0"
+        "string-width": "^3.0.0"
       },
       "dependencies": {
-	"ansi-regex": {
-	  "version": "4.1.0",
-	  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-	  "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-	  "dev": true
-	},
-	"is-fullwidth-code-point": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-	  "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-	  "dev": true
-	},
-	"string-width": {
-	  "version": "3.1.0",
-	  "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-	  "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-	  "dev": true,
-	  "requires": {
-	    "emoji-regex": "^7.0.1",
-	    "is-fullwidth-code-point": "^2.0.0",
-	    "strip-ansi": "^5.1.0"
-	  }
-	},
-	"strip-ansi": {
-	  "version": "5.2.0",
-	  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-	  "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-	  "dev": true,
-	  "requires": {
-	    "ansi-regex": "^4.1.0"
-	  }
-	}
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "ansi-colors": {
@@ -801,7 +801,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-	"array-uniq": "^1.0.1"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -951,41 +951,41 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-	"chalk": "^1.1.3",
-	"esutils": "^2.0.2",
-	"js-tokens": "^3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
-	"ansi-styles": {
-	  "version": "2.2.1",
-	  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-	  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-	  "dev": true
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
-	"chalk": {
-	  "version": "1.1.3",
-	  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-	  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-	  "dev": true,
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
-	    "ansi-styles": "^2.2.1",
-	    "escape-string-regexp": "^1.0.2",
-	    "has-ansi": "^2.0.0",
-	    "strip-ansi": "^3.0.0",
-	    "supports-color": "^2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
-	"js-tokens": {
-	  "version": "3.0.2",
-	  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-	  "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-	  "dev": true
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
         },
-	"supports-color": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-	  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-	  "dev": true
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -995,48 +995,48 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-	"babel-code-frame": "^6.26.0",
-	"babel-generator": "^6.26.0",
-	"babel-helpers": "^6.24.1",
-	"babel-messages": "^6.23.0",
-	"babel-register": "^6.26.0",
-	"babel-runtime": "^6.26.0",
-	"babel-template": "^6.26.0",
-	"babel-traverse": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"babylon": "^6.18.0",
-	"convert-source-map": "^1.5.1",
-	"debug": "^2.6.9",
-	"json5": "^0.5.1",
-	"lodash": "^4.17.4",
-	"minimatch": "^3.0.4",
-	"path-is-absolute": "^1.0.1",
-	"private": "^0.1.8",
-	"slash": "^1.0.0",
-	"source-map": "^0.5.7"
-    },
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
       "dependencies": {
-	"debug": {
-	  "version": "2.6.9",
-	  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-	  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-	  "dev": true,
-	  "requires": {
-	    "ms": "2.0.0"
-	  }
-	},
-	"json5": {
-	  "version": "0.5.1",
-	  "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-	  "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-	  "dev": true
-	},
-	"ms": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-	  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-	  "dev": true
-	}
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -1045,22 +1045,22 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-	"babel-messages": "^6.23.0",
-	"babel-runtime": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"detect-indent": "^4.0.0",
-	"jsesc": "^1.3.0",
-	"lodash": "^4.17.4",
-	"source-map": "^0.5.7",
-	"trim-right": "^1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
-	"jsesc": {
-	  "version": "1.3.0",
-	  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-	  "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-	  "dev": true
-	}
+        "jsesc": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "dev": true
+        }
       }
     },
     "babel-helper-bindify-decorators": {
@@ -1069,9 +1069,9 @@
       "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1080,9 +1080,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-	"babel-helper-explode-assignable-expression": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -1091,10 +1091,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-	"babel-helper-hoist-variables": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -1103,10 +1103,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-	"babel-helper-function-name": "^6.24.1",
-	"babel-runtime": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"lodash": "^4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -1115,9 +1115,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-explode-class": {
@@ -1126,10 +1126,10 @@
       "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
       "dev": true,
       "requires": {
-	"babel-helper-bindify-decorators": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -1138,11 +1138,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-	"babel-helper-get-function-arity": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -1151,8 +1151,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -1161,8 +1161,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -1171,8 +1171,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -1181,9 +1181,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"lodash": "^4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1192,11 +1192,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-	"babel-helper-function-name": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -1205,12 +1205,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-	"babel-helper-optimise-call-expression": "^6.24.1",
-	"babel-messages": "^6.23.0",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -1219,8 +1219,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -1229,7 +1229,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -1238,7 +1238,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -1313,9 +1313,9 @@
       "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
       "dev": true,
       "requires": {
-	"babel-helper-remap-async-to-generator": "^6.24.1",
-	"babel-plugin-syntax-async-generators": "^6.5.0",
-	"babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-async-to-generator": {
@@ -1324,9 +1324,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-	"babel-helper-remap-async-to-generator": "^6.24.1",
-	"babel-plugin-syntax-async-functions": "^6.8.0",
-	"babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-constructor-call": {
@@ -1335,9 +1335,9 @@
       "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-class-constructor-call": "^6.18.0",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -1346,10 +1346,10 @@
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "dev": true,
       "requires": {
-	"babel-helper-function-name": "^6.24.1",
-	"babel-plugin-syntax-class-properties": "^6.8.0",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-decorators": {
@@ -1358,11 +1358,11 @@
       "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
       "dev": true,
       "requires": {
-	"babel-helper-explode-class": "^6.24.1",
-	"babel-plugin-syntax-decorators": "^6.13.0",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -1371,7 +1371,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1380,7 +1380,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -1389,11 +1389,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.26.0",
-	"babel-template": "^6.26.0",
-	"babel-traverse": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"lodash": "^4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1402,15 +1402,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-	"babel-helper-define-map": "^6.24.1",
-	"babel-helper-function-name": "^6.24.1",
-	"babel-helper-optimise-call-expression": "^6.24.1",
-	"babel-helper-replace-supers": "^6.24.1",
-	"babel-messages": "^6.23.0",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -1419,8 +1419,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -1429,7 +1429,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1438,8 +1438,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -1448,7 +1448,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -1457,9 +1457,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-	"babel-helper-function-name": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -1468,7 +1468,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -1477,9 +1477,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-	"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1488,10 +1488,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-	"babel-plugin-transform-strict-mode": "^6.24.1",
-	"babel-runtime": "^6.26.0",
-	"babel-template": "^6.26.0",
-	"babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1500,9 +1500,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-	"babel-helper-hoist-variables": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -1511,9 +1511,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-	"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -1522,8 +1522,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-	"babel-helper-replace-supers": "^6.24.1",
-	"babel-runtime": "^6.22.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1532,12 +1532,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-	"babel-helper-call-delegate": "^6.24.1",
-	"babel-helper-get-function-arity": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-template": "^6.24.1",
-	"babel-traverse": "^6.24.1",
-	"babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1546,8 +1546,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -1556,7 +1556,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -1565,9 +1565,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-	"babel-helper-regex": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1576,7 +1576,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1585,7 +1585,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1594,9 +1594,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-	"babel-helper-regex": "^6.24.1",
-	"babel-runtime": "^6.22.0",
-	"regexpu-core": "^2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1605,9 +1605,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-	"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-	"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-	"babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-export-extensions": {
@@ -1616,8 +1616,8 @@
       "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-export-extensions": "^6.8.0",
-	"babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1626,8 +1626,8 @@
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-flow": "^6.18.0",
-	"babel-runtime": "^6.22.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1636,8 +1636,8 @@
       "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-	"babel-runtime": "^6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1646,7 +1646,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-	"regenerator-transform": "^0.10.0"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1655,8 +1655,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.22.0",
-	"babel-types": "^6.24.1"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-es2015": {
@@ -1665,30 +1665,30 @@
       "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
       "dev": true,
       "requires": {
-	"babel-plugin-check-es2015-constants": "^6.22.0",
-	"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-	"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-	"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-	"babel-plugin-transform-es2015-classes": "^6.24.1",
-	"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-	"babel-plugin-transform-es2015-destructuring": "^6.22.0",
-	"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-	"babel-plugin-transform-es2015-for-of": "^6.22.0",
-	"babel-plugin-transform-es2015-function-name": "^6.24.1",
-	"babel-plugin-transform-es2015-literals": "^6.22.0",
-	"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-	"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-	"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-	"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-	"babel-plugin-transform-es2015-object-super": "^6.24.1",
-	"babel-plugin-transform-es2015-parameters": "^6.24.1",
-	"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-	"babel-plugin-transform-es2015-spread": "^6.22.0",
-	"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-	"babel-plugin-transform-es2015-template-literals": "^6.22.0",
-	"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-	"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-	"babel-plugin-transform-regenerator": "^6.24.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
       }
     },
     "babel-preset-stage-1": {
@@ -1697,9 +1697,9 @@
       "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
       "dev": true,
       "requires": {
-	"babel-plugin-transform-class-constructor-call": "^6.24.1",
-	"babel-plugin-transform-export-extensions": "^6.22.0",
-	"babel-preset-stage-2": "^6.24.1"
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
       }
     },
     "babel-preset-stage-2": {
@@ -1708,10 +1708,10 @@
       "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-dynamic-import": "^6.18.0",
-	"babel-plugin-transform-class-properties": "^6.24.1",
-	"babel-plugin-transform-decorators": "^6.24.1",
-	"babel-preset-stage-3": "^6.24.1"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
       }
     },
     "babel-preset-stage-3": {
@@ -1720,11 +1720,11 @@
       "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
       "dev": true,
       "requires": {
-	"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-	"babel-plugin-transform-async-generator-functions": "^6.24.1",
-	"babel-plugin-transform-async-to-generator": "^6.24.1",
-	"babel-plugin-transform-exponentiation-operator": "^6.24.1",
-	"babel-plugin-transform-object-rest-spread": "^6.22.0"
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
       }
     },
     "babel-register": {
@@ -1733,13 +1733,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-	"babel-core": "^6.26.0",
-	"babel-runtime": "^6.26.0",
-	"core-js": "^2.5.0",
-	"home-or-tmp": "^2.0.0",
-	"lodash": "^4.17.4",
-	"mkdirp": "^0.5.1",
-	"source-map-support": "^0.4.15"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -1748,16 +1748,16 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-	"core-js": "^2.4.0",
-	"regenerator-runtime": "^0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
-	"regenerator-runtime": {
-	  "version": "0.11.1",
-	  "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-	  "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-	  "dev": true
-	}
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
       }
     },
     "babel-template": {
@@ -1766,11 +1766,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.26.0",
-	"babel-traverse": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"babylon": "^6.18.0",
-	"lodash": "^4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1779,38 +1779,38 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-	"babel-code-frame": "^6.26.0",
-	"babel-messages": "^6.23.0",
-	"babel-runtime": "^6.26.0",
-	"babel-types": "^6.26.0",
-	"babylon": "^6.18.0",
-	"debug": "^2.6.8",
-	"globals": "^9.18.0",
-	"invariant": "^2.2.2",
-	"lodash": "^4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
-	"debug": {
-	  "version": "2.6.9",
-	  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-	  "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-	  "dev": true,
-	  "requires": {
-	    "ms": "2.0.0"
-	  }
-	},
-	"globals": {
-	  "version": "9.18.0",
-	  "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-	  "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-	  "dev": true
-	},
-	"ms": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-	  "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-	  "dev": true
-	}
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "babel-types": {
@@ -1819,10 +1819,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.26.0",
-	"esutils": "^2.0.2",
-	"lodash": "^4.17.4",
-	"to-fast-properties": "^1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1847,49 +1847,49 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
-	"cache-base": "^1.0.1",
-	"class-utils": "^0.3.5",
-	"component-emitter": "^1.2.1",
-	"define-property": "^1.0.0",
-	"isobject": "^3.0.1",
-	"mixin-deep": "^1.2.0",
-	"pascalcase": "^0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
-	"define-property": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-	  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-	  "requires": {
-	    "is-descriptor": "^1.0.0"
-	  }
-	},
-	"is-accessor-descriptor": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-	  "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-	  "requires": {
-	    "kind-of": "^6.0.0"
-	  }
-	},
-	"is-data-descriptor": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-	  "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-	  "requires": {
-	    "kind-of": "^6.0.0"
-	  }
-	},
-	"is-descriptor": {
-	  "version": "1.0.2",
-	  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-	  "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-	  "requires": {
-	    "is-accessor-descriptor": "^1.0.0",
-	    "is-data-descriptor": "^1.0.0",
-	    "kind-of": "^6.0.2"
-	  }
-	}
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "base64-arraybuffer": {
@@ -2026,110 +2026,110 @@
       "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
       "dev": true,
       "requires": {
-	"ansi-align": "^3.0.0",
-	"camelcase": "^5.3.1",
-	"chalk": "^3.0.0",
-	"cli-boxes": "^2.2.0",
-	"string-width": "^4.1.0",
-	"term-size": "^2.1.0",
-	"type-fest": "^0.8.1",
-	"widest-line": "^3.1.0"
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
       },
       "dependencies": {
-	"ansi-regex": {
-	  "version": "5.0.0",
-	  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-	  "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-	  "dev": true
-	},
-	"ansi-styles": {
-	  "version": "4.2.1",
-	  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-	  "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-	  "dev": true,
-	  "requires": {
-	    "@types/color-name": "^1.1.1",
-	    "color-convert": "^2.0.1"
-	  }
-	},
-	"chalk": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-	  "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-	  "dev": true,
-	  "requires": {
-	    "ansi-styles": "^4.1.0",
-	    "supports-color": "^7.1.0"
-	  }
-	},
-	"color-convert": {
-	  "version": "2.0.1",
-	  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-	  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-	  "dev": true,
-	  "requires": {
-	    "color-name": "~1.1.4"
-	  }
-	},
-	"color-name": {
-	  "version": "1.1.4",
-	  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-	  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-	  "dev": true
-	},
-	"emoji-regex": {
-	  "version": "8.0.0",
-	  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-	  "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-	  "dev": true
-	},
-	"has-flag": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-	  "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-	  "dev": true
-	},
-	"is-fullwidth-code-point": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-	  "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-	  "dev": true
-	},
-	"string-width": {
-	  "version": "4.2.0",
-	  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-	  "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-	  "dev": true,
-	  "requires": {
-	    "emoji-regex": "^8.0.0",
-	    "is-fullwidth-code-point": "^3.0.0",
-	    "strip-ansi": "^6.0.0"
-	  }
-	},
-	"strip-ansi": {
-	  "version": "6.0.0",
-	  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-	  "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-	  "dev": true,
-	  "requires": {
-	    "ansi-regex": "^5.0.0"
-	  }
-	},
-	"supports-color": {
-	  "version": "7.1.0",
-	  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-	  "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-	  "dev": true,
-	  "requires": {
-	    "has-flag": "^4.0.0"
-	  }
-	},
-	"type-fest": {
-	  "version": "0.8.1",
-	  "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-	  "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-	  "dev": true
-	}
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -2198,8 +2198,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-	"buffer-alloc-unsafe": "^1.1.0",
-	"buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2336,29 +2336,29 @@
       "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "dev": true,
       "requires": {
-	"clone-response": "^1.0.2",
-	"get-stream": "^5.1.0",
-	"http-cache-semantics": "^4.0.0",
-	"keyv": "^3.0.0",
-	"lowercase-keys": "^2.0.0",
-	"normalize-url": "^4.1.0",
-	"responselike": "^1.0.2"
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
       },
       "dependencies": {
-	"get-stream": {
-	  "version": "5.1.0",
-	  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-	  "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-	  "dev": true,
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
           "requires": {
-	    "pump": "^3.0.0"
-      }
-    },
-	"lowercase-keys": {
-      "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-	  "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-	  "dev": true
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
         }
       }
     },
@@ -2571,7 +2571,7 @@
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
       "dev": true,
       "requires": {
-	"colors": "1.0.3"
+        "colors": "1.0.3"
       }
     },
     "cli-width": {
@@ -2643,15 +2643,15 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-	"mimic-response": "^1.0.0"
+        "mimic-response": "^1.0.0"
       },
       "dependencies": {
-	"mimic-response": {
-	  "version": "1.0.1",
-	  "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-	  "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-	  "dev": true
-	}
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "dev": true
+        }
       }
     },
     "clone-stats": {
@@ -2666,45 +2666,45 @@
       "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
       "dev": true,
       "requires": {
-	"inherits": "^2.0.1",
-	"process-nextick-args": "^2.0.0",
-	"readable-stream": "^2.3.5"
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
       },
       "dependencies": {
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-	  "dev": true
-	},
-	"readable-stream": {
-	  "version": "2.3.7",
-	  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-	  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-	    "core-util-is": "~1.0.0",
-	    "inherits": "~2.0.3",
-	    "isarray": "~1.0.0",
-	    "process-nextick-args": "~2.0.0",
-	    "safe-buffer": "~5.1.1",
-	    "string_decoder": "~1.1.1",
-	    "util-deprecate": "~1.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
-	"safe-buffer": {
-	  "version": "5.1.2",
-	  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-	  "dev": true
-	},
-	"string_decoder": {
-	  "version": "1.1.1",
-	  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-	  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-	    "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2920,25 +2920,25 @@
       "dev": true,
       "requires": {
         "dot-prop": "^5.2.0",
-	"graceful-fs": "^4.1.2",
-	"make-dir": "^3.0.0",
-	"unique-string": "^2.0.0",
-	"write-file-atomic": "^3.0.0",
-	"xdg-basedir": "^4.0.0"
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-	"write-file-atomic": {
+        "write-file-atomic": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
           "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-	  "dev": true,
-	  "requires": {
-	    "imurmurhash": "^0.1.4",
-	    "is-typedarray": "^1.0.0",
-	    "signal-exit": "^3.0.2",
-	    "typedarray-to-buffer": "^3.1.5"
-	  }
-	}
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
       }
     },
     "confusing-browser-globals": {
@@ -2989,15 +2989,15 @@
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
-	"safe-buffer": "~5.1.1"
+        "safe-buffer": "~5.1.1"
       },
       "dependencies": {
-	"safe-buffer": {
-	  "version": "5.1.2",
-	  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-	  "dev": true
-	}
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "cookie": {
@@ -3057,7 +3057,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-	"capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -3281,7 +3281,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-	"repeating": "^2.0.0"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -3310,24 +3310,24 @@
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "dev": true,
       "requires": {
-	"path-type": "^3.0.0"
+        "path-type": "^3.0.0"
       },
       "dependencies": {
-	"path-type": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-	  "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-	  "dev": true,
-	  "requires": {
-	    "pify": "^3.0.0"
-	  }
-	},
-	"pify": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-	  "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-	  "dev": true
-	}
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "dns-prefetch-control": {
@@ -3355,7 +3355,7 @@
       "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
       "dev": true,
       "requires": {
-	"is-obj": "^2.0.0"
+        "is-obj": "^2.0.0"
       }
     },
     "dotenv": {
@@ -3402,16 +3402,16 @@
       "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
       "dev": true,
       "requires": {
-	"errlop": "^2.0.0",
-	"semver": "^6.3.0"
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
-	"semver": {
-	  "version": "6.3.0",
-	  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-	  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-	  "dev": true
-	}
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -3532,7 +3532,7 @@
       "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
       "dev": true,
       "requires": {
-	"string-template": "~0.2.1"
+        "string-template": "~0.2.1"
       }
     },
     "error-ex": {
@@ -4027,55 +4027,55 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-	"fill-range": "^2.1.0"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
-	"fill-range": {
-	  "version": "2.2.4",
-	  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-	  "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-	  "dev": true,
-	  "requires": {
-	    "is-number": "^2.1.0",
-	    "isobject": "^2.0.0",
-	    "randomatic": "^3.0.0",
-	    "repeat-element": "^1.1.2",
-	    "repeat-string": "^1.5.2"
-	  }
-	},
-	"is-number": {
-	  "version": "2.1.0",
-	  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-	  "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-	  "dev": true,
-	  "requires": {
-	    "kind-of": "^3.0.2"
-	  }
-	},
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-	  "dev": true
-	},
-	"isobject": {
-	  "version": "2.1.0",
-	  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-	  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-	  "dev": true,
-	  "requires": {
-	    "isarray": "1.0.0"
-	  }
-	},
-	"kind-of": {
-	  "version": "3.2.2",
-	  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-	  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-	  "dev": true,
-	  "requires": {
-	    "is-buffer": "^1.1.5"
-	  }
-	}
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "dev": true,
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "expand-template": {
@@ -4310,35 +4310,35 @@
       "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
       "dev": true,
       "requires": {
-	"@mrmlnc/readdir-enhanced": "^2.2.1",
-	"@nodelib/fs.stat": "^1.1.2",
-	"glob-parent": "^3.1.0",
-	"is-glob": "^4.0.0",
-	"merge2": "^1.2.3",
-	"micromatch": "^3.1.10"
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
       },
       "dependencies": {
-	"glob-parent": {
-	  "version": "3.1.0",
-	  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-	  "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-	  "dev": true,
-	  "requires": {
-	    "is-glob": "^3.1.0",
-	    "path-dirname": "^1.0.0"
-	  },
-	  "dependencies": {
-	    "is-glob": {
-	      "version": "3.1.0",
-	      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-	      "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-	      "dev": true,
-	      "requires": {
-		"is-extglob": "^2.1.0"
-	      }
-	    }
-	  }
-	}
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        }
       }
     },
     "fast-json-stable-stringify": {
@@ -4592,45 +4592,45 @@
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "dev": true,
       "requires": {
-	"readable-stream": "^2.0.2"
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-	  "dev": true
-	},
-	"readable-stream": {
-	  "version": "2.3.7",
-	  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-	  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-	  "dev": true,
-	  "requires": {
-	    "core-util-is": "~1.0.0",
-	    "inherits": "~2.0.3",
-	    "isarray": "~1.0.0",
-	    "process-nextick-args": "~2.0.0",
-	    "safe-buffer": "~5.1.1",
-	    "string_decoder": "~1.1.1",
-	    "util-deprecate": "~1.0.1"
-	  }
-	},
-	"safe-buffer": {
-	  "version": "5.1.2",
-	  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-	  "dev": true
-	},
-	"string_decoder": {
-	  "version": "1.1.1",
-	  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-	  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-	  "dev": true,
-	  "requires": {
-	    "safe-buffer": "~5.1.0"
-	  }
-	}
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "flat": {
@@ -4692,7 +4692,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-	"for-in": "^1.0.1"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -4810,31 +4810,31 @@
       "integrity": "sha512-V6M2aY72elNFRGtPIZN98l/ANDIS1NtyDa8ypMwfkS1luWLiCFw5en+jXE9+v++c5y6aP85wshlRXFklsTfoRg==",
       "dev": true,
       "requires": {
-	"@feathersjs/jscodeshift": "^0.5.0",
-	"@feathersjs/tools": "^0.1.7",
-	"lodash": "^4.17.15",
-	"node-dir": "^0.1.17",
-	"randomstring": "^1.1.5",
+        "@feathersjs/jscodeshift": "^0.5.0",
+        "@feathersjs/tools": "^0.1.7",
+        "lodash": "^4.17.15",
+        "node-dir": "^0.1.17",
+        "randomstring": "^1.1.5",
         "semver": "^7.1.3",
-	"validate-npm-package-name": "^3.0.0",
+        "validate-npm-package-name": "^3.0.0",
         "yeoman-generator": "^4.5.0"
       },
       "dependencies": {
-	"node-dir": {
-	  "version": "0.1.17",
-	  "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-	  "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-	  "dev": true,
-	  "requires": {
-	    "minimatch": "^3.0.2"
-	  }
-	},
-	"semver": {
+        "node-dir": {
+          "version": "0.1.17",
+          "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+          "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.2"
+          }
+        },
+        "semver": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
           "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
-	  "dev": true
-	}
+          "dev": true
+        }
       }
     },
     "generator-feathers-plugin": {
@@ -4843,358 +4843,358 @@
       "integrity": "sha512-O2R84Ir3LxmhY/Wj2eii5DMOrVRpD3mndkICybjxSir4T8YPxjy46J78BgG5fFLzmZOQM2mTlsZ/LFDq1Cwp+g==",
       "dev": true,
       "requires": {
-	"yeoman-generator": "^3.0.0"
+        "yeoman-generator": "^3.0.0"
       },
       "dependencies": {
-	"array-differ": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-	  "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-	  "dev": true
-	},
-	"arrify": {
-	  "version": "1.0.1",
-	  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-	  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-	  "dev": true
-	},
-	"debug": {
-	  "version": "4.1.1",
-	  "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-	  "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-	  "dev": true,
-	  "requires": {
-	    "ms": "^2.1.1"
-	  }
-	},
-	"decompress-response": {
-	  "version": "3.3.0",
-	  "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-	  "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-	  "dev": true,
-	  "requires": {
-	    "mimic-response": "^1.0.0"
-	  }
-	},
-	"dir-glob": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-	  "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-	  "dev": true,
-	  "requires": {
-	    "arrify": "^1.0.1",
-	    "path-type": "^3.0.0"
-	  }
-	},
-	"find-up": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-	  "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-	  "dev": true,
-	  "requires": {
-	    "locate-path": "^3.0.0"
-	  }
-	},
-	"gh-got": {
-	  "version": "6.0.0",
-	  "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
-	  "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
-	  "dev": true,
-	  "requires": {
-	    "got": "^7.0.0",
-	    "is-plain-obj": "^1.1.0"
-	  }
-	},
-	"github-username": {
-	  "version": "4.1.0",
-	  "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
-	  "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
-	  "dev": true,
-	  "requires": {
-	    "gh-got": "^6.0.0"
-	  }
-	},
-	"globby": {
-	  "version": "8.0.2",
-	  "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-	  "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
-	  "dev": true,
-	  "requires": {
-	    "array-union": "^1.0.1",
-	    "dir-glob": "2.0.0",
-	    "fast-glob": "^2.0.2",
-	    "glob": "^7.1.2",
-	    "ignore": "^3.3.5",
-	    "pify": "^3.0.0",
-	    "slash": "^1.0.0"
-	  }
-	},
-	"got": {
-	  "version": "7.1.0",
-	  "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-	  "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-	  "dev": true,
-	  "requires": {
-	    "decompress-response": "^3.2.0",
-	    "duplexer3": "^0.1.4",
-	    "get-stream": "^3.0.0",
-	    "is-plain-obj": "^1.1.0",
-	    "is-retry-allowed": "^1.0.0",
-	    "is-stream": "^1.0.0",
-	    "isurl": "^1.0.0-alpha5",
-	    "lowercase-keys": "^1.0.0",
-	    "p-cancelable": "^0.3.0",
-	    "p-timeout": "^1.1.1",
-	    "safe-buffer": "^5.0.1",
-	    "timed-out": "^4.0.0",
-	    "url-parse-lax": "^1.0.0",
-	    "url-to-options": "^1.0.1"
-	  }
-	},
-	"ignore": {
-	  "version": "3.3.10",
-	  "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-	  "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-	  "dev": true
-	},
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-	  "dev": true
-	},
-	"isbinaryfile": {
-	  "version": "3.0.3",
-	  "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-	  "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-	  "dev": true,
-	  "requires": {
-	    "buffer-alloc": "^1.2.0"
-	  }
-	},
-	"load-json-file": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-	  "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-	  "dev": true,
-	  "requires": {
-	    "graceful-fs": "^4.1.2",
-	    "parse-json": "^4.0.0",
-	    "pify": "^3.0.0",
-	    "strip-bom": "^3.0.0"
-	  }
-	},
-	"locate-path": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-	  "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-	  "dev": true,
-	  "requires": {
-	    "p-locate": "^3.0.0",
-	    "path-exists": "^3.0.0"
-	  }
-	},
-	"make-dir": {
-	  "version": "1.3.0",
-	  "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-	  "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-	  "dev": true,
-	  "requires": {
-	    "pify": "^3.0.0"
-	  }
-	},
-	"mem-fs-editor": {
-	  "version": "5.1.0",
-	  "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-5.1.0.tgz",
-	  "integrity": "sha512-2Yt2GCYEbcotYbIJagmow4gEtHDqzpq5XN94+yAx/NT5+bGqIjkXnm3KCUQfE6kRfScGp9IZknScoGRKu8L78w==",
-	  "dev": true,
-	  "requires": {
-	    "commondir": "^1.0.1",
-	    "deep-extend": "^0.6.0",
-	    "ejs": "^2.5.9",
-	    "glob": "^7.0.3",
-	    "globby": "^8.0.1",
-	    "isbinaryfile": "^3.0.2",
-	    "mkdirp": "^0.5.0",
-	    "multimatch": "^2.0.0",
-	    "rimraf": "^2.2.8",
-	    "through2": "^2.0.0",
-	    "vinyl": "^2.0.1"
-	  },
-	  "dependencies": {
-	    "through2": {
-	      "version": "2.0.5",
-	      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-	      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-	      "dev": true,
-	      "requires": {
-		"readable-stream": "~2.3.6",
-		"xtend": "~4.0.1"
-	      }
-	    }
-	  }
-	},
-	"mimic-response": {
-	  "version": "1.0.1",
-	  "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-	  "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-	  "dev": true
-	},
-	"multimatch": {
-	  "version": "2.1.0",
-	  "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-	  "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-	  "dev": true,
-	  "requires": {
-	    "array-differ": "^1.0.0",
-	    "array-union": "^1.0.1",
-	    "arrify": "^1.0.0",
-	    "minimatch": "^3.0.0"
-	  }
-	},
-	"p-limit": {
-	  "version": "2.2.2",
-	  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-	  "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-	  "dev": true,
-	  "requires": {
-	    "p-try": "^2.0.0"
-	  }
-	},
-	"p-locate": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-	  "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-	  "dev": true,
-	  "requires": {
-	    "p-limit": "^2.0.0"
-	  }
-	},
-	"p-try": {
-	  "version": "2.2.0",
-	  "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-	  "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-	  "dev": true
-	},
-	"parse-json": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-	  "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-	  "dev": true,
-	  "requires": {
-	    "error-ex": "^1.3.1",
-	    "json-parse-better-errors": "^1.0.1"
-	  }
-	},
-	"path-type": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-	  "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-	  "dev": true,
-	  "requires": {
-	    "pify": "^3.0.0"
-	  }
-	},
-	"pify": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-	  "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-	  "dev": true
-	},
-	"read-pkg": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-	  "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-	  "dev": true,
-	  "requires": {
-	    "load-json-file": "^4.0.0",
-	    "normalize-package-data": "^2.3.2",
-	    "path-type": "^3.0.0"
-	  }
-	},
-	"read-pkg-up": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-	  "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-	  "dev": true,
-	  "requires": {
-	    "find-up": "^3.0.0",
-	    "read-pkg": "^3.0.0"
-	  }
-	},
-	"readable-stream": {
-	  "version": "2.3.7",
-	  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-	  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-	  "dev": true,
-	  "requires": {
-	    "core-util-is": "~1.0.0",
-	    "inherits": "~2.0.3",
-	    "isarray": "~1.0.0",
-	    "process-nextick-args": "~2.0.0",
-	    "safe-buffer": "~5.1.1",
-	    "string_decoder": "~1.1.1",
-	    "util-deprecate": "~1.0.1"
-	  },
-	  "dependencies": {
-	    "safe-buffer": {
-	      "version": "5.1.2",
-	      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-	      "dev": true
-	    }
-	  }
-	},
-	"string_decoder": {
-      "version": "1.1.1",
-	  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-	  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-	  "dev": true,
-	  "requires": {
-	    "safe-buffer": "~5.1.0"
-    },
-	  "dependencies": {
-	    "safe-buffer": {
-	      "version": "5.1.2",
-	      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-	    }
-      }
-    },
-	"yeoman-generator": {
-	  "version": "3.2.0",
-	  "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.2.0.tgz",
-	  "integrity": "sha512-iR/qb2je3GdXtSfxgvOXxUW0Cp8+C6LaZaNlK2BAICzFNzwHtM10t/QBwz5Ea9nk6xVDQNj4Q889TjCXGuIv8w==",
-	  "dev": true,
-      "requires": {
-	    "async": "^2.6.0",
-	    "chalk": "^2.3.0",
-	    "cli-table": "^0.3.1",
-	    "cross-spawn": "^6.0.5",
-	    "dargs": "^6.0.0",
-	    "dateformat": "^3.0.3",
-	    "debug": "^4.1.0",
-	    "detect-conflict": "^1.0.0",
-	    "error": "^7.0.2",
-	    "find-up": "^3.0.0",
-	    "github-username": "^4.0.0",
-	    "istextorbinary": "^2.2.1",
-	    "lodash": "^4.17.10",
-	    "make-dir": "^1.1.0",
-	    "mem-fs-editor": "^5.0.0",
-	    "minimist": "^1.2.0",
-	    "pretty-bytes": "^5.1.0",
-	    "read-chunk": "^3.0.0",
-	    "read-pkg-up": "^4.0.0",
-	    "rimraf": "^2.6.2",
-	    "run-async": "^2.0.0",
-	    "shelljs": "^0.8.0",
-	    "text-table": "^0.2.0",
-	    "through2": "^3.0.0",
-	    "yeoman-environment": "^2.0.5"
-	  }
-	}
+        "array-differ": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+          "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+          "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "gh-got": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-6.0.0.tgz",
+          "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
+          "dev": true,
+          "requires": {
+            "got": "^7.0.0",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "github-username": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-4.1.0.tgz",
+          "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
+          "dev": true,
+          "requires": {
+            "gh-got": "^6.0.0"
+          }
+        },
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "dev": true,
+          "requires": {
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "isbinaryfile": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
+          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
+          "dev": true,
+          "requires": {
+            "buffer-alloc": "^1.2.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "mem-fs-editor": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-5.1.0.tgz",
+          "integrity": "sha512-2Yt2GCYEbcotYbIJagmow4gEtHDqzpq5XN94+yAx/NT5+bGqIjkXnm3KCUQfE6kRfScGp9IZknScoGRKu8L78w==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "deep-extend": "^0.6.0",
+            "ejs": "^2.5.9",
+            "glob": "^7.0.3",
+            "globby": "^8.0.1",
+            "isbinaryfile": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "multimatch": "^2.0.0",
+            "rimraf": "^2.2.8",
+            "through2": "^2.0.0",
+            "vinyl": "^2.0.1"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+              "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+              "dev": true,
+              "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+              }
+            }
+          }
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "dev": true
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+          "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+          "dev": true,
+          "requires": {
+            "array-differ": "^1.0.0",
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "minimatch": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "yeoman-generator": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-3.2.0.tgz",
+          "integrity": "sha512-iR/qb2je3GdXtSfxgvOXxUW0Cp8+C6LaZaNlK2BAICzFNzwHtM10t/QBwz5Ea9nk6xVDQNj4Q889TjCXGuIv8w==",
+          "dev": true,
+          "requires": {
+            "async": "^2.6.0",
+            "chalk": "^2.3.0",
+            "cli-table": "^0.3.1",
+            "cross-spawn": "^6.0.5",
+            "dargs": "^6.0.0",
+            "dateformat": "^3.0.3",
+            "debug": "^4.1.0",
+            "detect-conflict": "^1.0.0",
+            "error": "^7.0.2",
+            "find-up": "^3.0.0",
+            "github-username": "^4.0.0",
+            "istextorbinary": "^2.2.1",
+            "lodash": "^4.17.10",
+            "make-dir": "^1.1.0",
+            "mem-fs-editor": "^5.0.0",
+            "minimist": "^1.2.0",
+            "pretty-bytes": "^5.1.0",
+            "read-chunk": "^3.0.0",
+            "read-pkg-up": "^4.0.0",
+            "rimraf": "^2.6.2",
+            "run-async": "^2.0.0",
+            "shelljs": "^0.8.0",
+            "text-table": "^0.2.0",
+            "through2": "^3.0.0",
+            "yeoman-environment": "^2.0.5"
+          }
+        }
       }
     },
     "get-caller-file": {
@@ -5228,8 +5228,8 @@
       "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
       "dev": true,
       "requires": {
-	"got": "^6.2.0",
-	"is-plain-obj": "^1.1.0"
+        "got": "^6.2.0",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "github-from-package": {
@@ -5243,7 +5243,7 @@
       "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
       "dev": true,
       "requires": {
-	"gh-got": "^5.0.0"
+        "gh-got": "^5.0.0"
       }
     },
     "glob": {
@@ -5266,34 +5266,34 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-	"glob-parent": "^2.0.0",
-	"is-glob": "^2.0.0"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
-	"glob-parent": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-	  "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-	  "dev": true,
-	  "requires": {
-	    "is-glob": "^2.0.0"
-	  }
-	},
-	"is-extglob": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-	  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-	  "dev": true
-	},
-	"is-glob": {
-	  "version": "2.0.1",
-	  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-	  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-	  "dev": true,
-	  "requires": {
-	    "is-extglob": "^1.0.0"
-	  }
-	}
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -5317,7 +5317,7 @@
       "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "dev": true,
       "requires": {
-	"ini": "^1.3.5"
+        "ini": "^1.3.5"
       }
     },
     "globals": {
@@ -5332,28 +5332,28 @@
       "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
       "dev": true,
       "requires": {
-	"@types/glob": "^7.1.1",
-	"array-union": "^1.0.2",
-	"dir-glob": "^2.2.2",
-	"fast-glob": "^2.2.6",
-	"glob": "^7.1.3",
-	"ignore": "^4.0.3",
-	"pify": "^4.0.1",
-	"slash": "^2.0.0"
+        "@types/glob": "^7.1.1",
+        "array-union": "^1.0.2",
+        "dir-glob": "^2.2.2",
+        "fast-glob": "^2.2.6",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.3",
+        "pify": "^4.0.1",
+        "slash": "^2.0.0"
       },
       "dependencies": {
-	"pify": {
-	  "version": "4.0.1",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-	  "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-	  "dev": true
-	},
-	"slash": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-	  "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-	  "dev": true
-	}
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
       }
     },
     "google-protobuf": {
@@ -5367,17 +5367,17 @@
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
-	"create-error-class": "^3.0.0",
-	"duplexer3": "^0.1.4",
-	"get-stream": "^3.0.0",
-	"is-redirect": "^1.0.0",
-	"is-retry-allowed": "^1.0.0",
-	"is-stream": "^1.0.0",
-	"lowercase-keys": "^1.0.0",
-	"safe-buffer": "^5.0.1",
-	"timed-out": "^4.0.0",
-	"unzip-response": "^2.0.1",
-	"url-parse-lax": "^1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -5478,7 +5478,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-	"ansi-regex": "^2.0.0"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -5522,7 +5522,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-	"has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "has-unicode": {
@@ -5632,8 +5632,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-	"os-homedir": "^1.0.0",
-	"os-tmpdir": "^1.0.1"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -5881,7 +5881,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-	"loose-envify": "^1.0.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -5942,7 +5942,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-	"ci-info": "^2.0.0"
+        "ci-info": "^2.0.0"
       }
     },
     "is-data-descriptor": {
@@ -5997,7 +5997,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-	"is-primitive": "^2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -6038,8 +6038,8 @@
       "integrity": "sha512-oiEcGoQbGc+3/iijAijrK2qFpkNoNjsHOm/5V5iaeydyrS/hnwaRCEgH5cpW0P3T1lSjV5piB7S5b5lEugNLhg==",
       "dev": true,
       "requires": {
-	"global-dirs": "^2.0.1",
-	"is-path-inside": "^3.0.1"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
       }
     },
     "is-npm": {
@@ -6146,7 +6146,7 @@
       "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
       "dev": true,
       "requires": {
-	"scoped-regex": "^1.0.0"
+        "scoped-regex": "^1.0.0"
       }
     },
     "is-stream": {
@@ -6218,9 +6218,9 @@
       "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
       "dev": true,
       "requires": {
-	"binaryextensions": "^2.1.2",
-	"editions": "^2.2.0",
-	"textextensions": "^2.5.0"
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
       }
     },
     "isurl": {
@@ -6229,8 +6229,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-	"has-to-string-tag-x": "^1.2.0",
-	"is-object": "^1.0.1"
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
       }
     },
     "jmespath": {
@@ -6322,7 +6322,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-	"graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -6383,7 +6383,7 @@
       "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
       "dev": true,
       "requires": {
-	"json-buffer": "3.0.0"
+        "json-buffer": "3.0.0"
       }
     },
     "kind-of": {
@@ -6397,7 +6397,7 @@
       "integrity": "sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==",
       "dev": true,
       "requires": {
-	"package-json": "^6.3.0"
+        "package-json": "^6.3.0"
       }
     },
     "levn": {
@@ -6538,7 +6538,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-	"js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lowercase-keys": {
@@ -6569,15 +6569,15 @@
       "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
       "dev": true,
       "requires": {
-	"semver": "^6.0.0"
+        "semver": "^6.0.0"
       },
       "dependencies": {
-	"semver": {
-	  "version": "6.3.0",
-	  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-	  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-	  "dev": true
-	}
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "map-cache": {
@@ -6615,86 +6615,86 @@
       "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
       "dev": true,
       "requires": {
-	"through2": "^2.0.0",
-	"vinyl": "^1.1.0",
-	"vinyl-file": "^2.0.0"
+        "through2": "^2.0.0",
+        "vinyl": "^1.1.0",
+        "vinyl-file": "^2.0.0"
       },
       "dependencies": {
-	"clone": {
-	  "version": "1.0.4",
-	  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-	  "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-	  "dev": true
-	},
-	"clone-stats": {
-	  "version": "0.0.1",
-	  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-	  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-	  "dev": true
-	},
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-	  "dev": true
-	},
-	"readable-stream": {
-	  "version": "2.3.7",
-	  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-	  "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-	  "dev": true,
-	  "requires": {
-	    "core-util-is": "~1.0.0",
-	    "inherits": "~2.0.3",
-	    "isarray": "~1.0.0",
-	    "process-nextick-args": "~2.0.0",
-	    "safe-buffer": "~5.1.1",
-	    "string_decoder": "~1.1.1",
-	    "util-deprecate": "~1.0.1"
-	  }
-	},
-	"replace-ext": {
-	  "version": "0.0.1",
-	  "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-	  "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-	  "dev": true
-	},
-	"safe-buffer": {
-	  "version": "5.1.2",
-	  "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-	  "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-	  "dev": true
-	},
-	"string_decoder": {
-	  "version": "1.1.1",
-	  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-	  "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-	  "dev": true,
-	  "requires": {
-	    "safe-buffer": "~5.1.0"
-	  }
-	},
-	"through2": {
-	  "version": "2.0.5",
-	  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-	  "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-	  "dev": true,
-	  "requires": {
-	    "readable-stream": "~2.3.6",
-	    "xtend": "~4.0.1"
-	  }
-	},
-	"vinyl": {
-	  "version": "1.2.0",
-	  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-	  "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-	  "dev": true,
-	  "requires": {
-	    "clone": "^1.0.0",
-	    "clone-stats": "^0.0.1",
-	    "replace-ext": "0.0.1"
-	  }
-	}
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
       }
     },
     "mem-fs-editor": {
@@ -6703,17 +6703,17 @@
       "integrity": "sha512-e0WfJAMm8Gv1mP5fEq/Blzy6Lt1VbLg7gNnZmZak7nhrBTibs+c6nQ4SKs/ZyJYHS1mFgDJeopsLAv7Ow0FMFg==",
       "dev": true,
       "requires": {
-	"commondir": "^1.0.1",
-	"deep-extend": "^0.6.0",
-	"ejs": "^2.6.1",
-	"glob": "^7.1.4",
-	"globby": "^9.2.0",
-	"isbinaryfile": "^4.0.0",
-	"mkdirp": "^0.5.0",
-	"multimatch": "^4.0.0",
-	"rimraf": "^2.6.3",
-	"through2": "^3.0.1",
-	"vinyl": "^2.2.0"
+        "commondir": "^1.0.1",
+        "deep-extend": "^0.6.0",
+        "ejs": "^2.6.1",
+        "glob": "^7.1.4",
+        "globby": "^9.2.0",
+        "isbinaryfile": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "multimatch": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "through2": "^3.0.1",
+        "vinyl": "^2.2.0"
       }
     },
     "memoizee": {
@@ -7020,19 +7020,19 @@
       "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
       "dev": true,
       "requires": {
-	"@types/minimatch": "^3.0.3",
-	"array-differ": "^3.0.0",
-	"array-union": "^2.1.0",
-	"arrify": "^2.0.1",
-	"minimatch": "^3.0.4"
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
       },
       "dependencies": {
-	"array-union": {
-	  "version": "2.1.0",
-	  "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-	  "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-	  "dev": true
-	}
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        }
       }
     },
     "mustache": {
@@ -7226,39 +7226,39 @@
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
-	"chalk": "~0.4.0",
-	"underscore": "~1.6.0"
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
       },
       "dependencies": {
-	"ansi-styles": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-	  "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
-	  "dev": true
-	},
-	"chalk": {
-	  "version": "0.4.0",
-	  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-	  "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-	  "dev": true,
-	  "requires": {
-	    "ansi-styles": "~1.0.0",
-	    "has-color": "~0.1.0",
-	    "strip-ansi": "~0.1.0"
-	  }
-	},
-	"strip-ansi": {
-	  "version": "0.1.1",
-	  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-	  "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-	  "dev": true
-	},
-	"underscore": {
-	  "version": "1.6.0",
-	  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-	  "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-	  "dev": true
-	}
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
+          "dev": true
+        }
       }
     },
     "noop-logger": {
@@ -7296,7 +7296,7 @@
       "integrity": "sha512-/WsPb3Q+tWIoVN0duv65J5WZey7Ivng5d1N7Oia1LRV6IVGtqH30qbTh4t/ZLrHJrXkmPGjXYO6gDYpWP+tniw==",
       "dev": true,
       "requires": {
-	"bluebird": "^3.4.1"
+        "bluebird": "^3.4.1"
       }
     },
     "npmlog": {
@@ -7419,8 +7419,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-	"for-own": "^0.1.4",
-	"is-extendable": "^0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -7535,7 +7535,7 @@
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
       "requires": {
-	"p-finally": "^1.0.0"
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -7550,82 +7550,82 @@
       "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "dev": true,
       "requires": {
-	"got": "^9.6.0",
-	"registry-auth-token": "^4.0.0",
-	"registry-url": "^5.0.0",
-	"semver": "^6.2.0"
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
       },
       "dependencies": {
-	"decompress-response": {
-	  "version": "3.3.0",
-	  "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-	  "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-	  "dev": true,
-	  "requires": {
-	    "mimic-response": "^1.0.0"
-	  }
-	},
-	"get-stream": {
-	  "version": "4.1.0",
-	  "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-	  "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-	  "dev": true,
-	  "requires": {
-	    "pump": "^3.0.0"
-	  }
-	},
-	"got": {
-	  "version": "9.6.0",
-	  "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-	  "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-	  "dev": true,
-	  "requires": {
-	    "@sindresorhus/is": "^0.14.0",
-	    "@szmarczak/http-timer": "^1.1.2",
-	    "cacheable-request": "^6.0.0",
-	    "decompress-response": "^3.3.0",
-	    "duplexer3": "^0.1.4",
-	    "get-stream": "^4.1.0",
-	    "lowercase-keys": "^1.0.1",
-	    "mimic-response": "^1.0.1",
-	    "p-cancelable": "^1.0.0",
-	    "to-readable-stream": "^1.0.0",
-	    "url-parse-lax": "^3.0.0"
-	  }
-	},
-	"mimic-response": {
-	  "version": "1.0.1",
-	  "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-	  "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-	  "dev": true
-	},
-	"p-cancelable": {
-	  "version": "1.1.0",
-	  "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-	  "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-	  "dev": true
-	},
-	"prepend-http": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-	  "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-	  "dev": true
-	},
-	"semver": {
-	  "version": "6.3.0",
-	  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-	  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-	  "dev": true
-	},
-	"url-parse-lax": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-	  "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-	  "dev": true,
-	  "requires": {
-	    "prepend-http": "^2.0.0"
-	  }
-	}
+        "decompress-response": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "got": {
+          "version": "9.6.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+          "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^0.14.0",
+            "@szmarczak/http-timer": "^1.1.2",
+            "cacheable-request": "^6.0.0",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^4.1.0",
+            "lowercase-keys": "^1.0.1",
+            "mimic-response": "^1.0.1",
+            "p-cancelable": "^1.0.0",
+            "to-readable-stream": "^1.0.0",
+            "url-parse-lax": "^3.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+          "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
       }
     },
     "packet-reader": {
@@ -7648,27 +7648,27 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-	"glob-base": "^0.3.0",
-	"is-dotfile": "^1.0.0",
-	"is-extglob": "^1.0.0",
-	"is-glob": "^2.0.0"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
-	"is-extglob": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-	  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-	  "dev": true
-	},
-	"is-glob": {
-	  "version": "2.0.1",
-	  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-	  "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-	  "dev": true,
-	  "requires": {
-	    "is-extglob": "^1.0.0"
-	  }
-	}
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
       }
     },
     "parse-json": {
@@ -7874,7 +7874,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-	"pinkie": "^2.0.0"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -8045,17 +8045,17 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-	"is-number": "^4.0.0",
-	"kind-of": "^6.0.0",
-	"math-random": "^1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
-	"is-number": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-	  "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-	  "dev": true
-	}
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        }
       }
     },
     "randomstring": {
@@ -8064,7 +8064,7 @@
       "integrity": "sha1-bfBij3XL1ZMpMNn+OrTpVqGFGMM=",
       "dev": true,
       "requires": {
-	"array-uniq": "1.0.2"
+        "array-uniq": "1.0.2"
       }
     },
     "range-parser": {
@@ -8100,16 +8100,16 @@
       "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
       "dev": true,
       "requires": {
-	"pify": "^4.0.1",
-	"with-open-file": "^0.1.6"
+        "pify": "^4.0.1",
+        "with-open-file": "^0.1.6"
       },
       "dependencies": {
-	"pify": {
-	  "version": "4.0.1",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-	  "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-	  "dev": true
-	}
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "read-pkg": {
@@ -8166,18 +8166,18 @@
       "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
       "dev": true,
       "requires": {
-	"ast-types": "0.9.6",
-	"esprima": "~3.1.0",
-	"private": "~0.1.5",
-	"source-map": "~0.5.0"
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
       },
       "dependencies": {
-	"esprima": {
-	  "version": "3.1.3",
-	  "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-	  "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-	  "dev": true
-	}
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
       }
     },
     "rechoir": {
@@ -8186,7 +8186,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-	"resolve": "^1.1.6"
+        "resolve": "^1.1.6"
       }
     },
     "redis": {
@@ -8236,9 +8236,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-	"babel-runtime": "^6.18.0",
-	"babel-types": "^6.19.0",
-	"private": "^0.1.6"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -8247,7 +8247,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-	"is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -8271,9 +8271,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-	"regenerate": "^1.2.1",
-	"regjsgen": "^0.2.0",
-	"regjsparser": "^0.1.4"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -8282,7 +8282,7 @@
       "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
       "dev": true,
       "requires": {
-	"rc": "^1.2.8"
+        "rc": "^1.2.8"
       }
     },
     "registry-url": {
@@ -8291,7 +8291,7 @@
       "integrity": "sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==",
       "dev": true,
       "requires": {
-	"rc": "^1.2.8"
+        "rc": "^1.2.8"
       }
     },
     "regjsgen": {
@@ -8306,7 +8306,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-	"jsesc": "~0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "remove-trailing-separator": {
@@ -8331,7 +8331,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-	"is-finite": "^1.0.0"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -8456,7 +8456,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-	"lowercase-keys": "^1.0.0"
+        "lowercase-keys": "^1.0.0"
       }
     },
     "restore-cursor": {
@@ -8549,15 +8549,15 @@
       "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "dev": true,
       "requires": {
-	"semver": "^6.3.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
-	"semver": {
-	  "version": "6.3.0",
-	  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-	  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-	  "dev": true
-	}
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "send": {
@@ -8759,9 +8759,9 @@
       "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "dev": true,
       "requires": {
-	"glob": "^7.0.0",
-	"interpret": "^1.0.0",
-	"rechoir": "^0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shimmer": {
@@ -9083,7 +9083,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-	"source-map": "^0.5.6"
+        "source-map": "^0.5.6"
       }
     },
     "source-map-url": {
@@ -9264,19 +9264,19 @@
       "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
       "dev": true,
       "requires": {
-	"first-chunk-stream": "^2.0.0",
-	"strip-bom": "^2.0.0"
+        "first-chunk-stream": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
-	"strip-bom": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-	  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-	  "dev": true,
-	  "requires": {
-	    "is-utf8": "^0.2.0"
-	  }
-	}
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
       }
     },
     "strip-json-comments": {
@@ -9407,7 +9407,7 @@
       "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "dev": true,
       "requires": {
-	"rimraf": "~2.6.2"
+        "rimraf": "~2.6.2"
       }
     },
     "term-size": {
@@ -9444,29 +9444,29 @@
       "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
       "dev": true,
       "requires": {
-	"readable-stream": "2 || 3"
+        "readable-stream": "2 || 3"
       },
       "dependencies": {
-	"readable-stream": {
+        "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-	  "dev": true,
-	  "requires": {
-	    "inherits": "^2.0.3",
-	    "string_decoder": "^1.1.1",
-	    "util-deprecate": "^1.0.1"
-	  }
-	},
-	"string_decoder": {
-	  "version": "1.3.0",
-	  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-	  "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-	  "dev": true,
-	  "requires": {
-	    "safe-buffer": "~5.2.0"
-	  }
-	}
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
       }
     },
     "timed-out": {
@@ -9649,7 +9649,7 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dev": true,
       "requires": {
-	"is-typedarray": "^1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "uberproto": {
@@ -9692,7 +9692,7 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "dev": true,
       "requires": {
-	"crypto-random-string": "^2.0.0"
+        "crypto-random-string": "^2.0.0"
       }
     },
     "universalify": {
@@ -9730,21 +9730,21 @@
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
-		"isarray": "1.0.0"
-	      }
-	    }
-	  }
-	},
-	"has-values": {
-	  "version": "0.1.4",
-	  "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-	  "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-	},
-	"isarray": {
-	  "version": "1.0.0",
-	  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-	  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-	}
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
       }
     },
     "untildify": {
@@ -9765,69 +9765,69 @@
       "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
       "dev": true,
       "requires": {
-	"boxen": "^4.2.0",
-	"chalk": "^3.0.0",
+        "boxen": "^4.2.0",
+        "chalk": "^3.0.0",
         "configstore": "^5.0.1",
-	"has-yarn": "^2.1.0",
-	"import-lazy": "^2.1.0",
-	"is-ci": "^2.0.0",
-	"is-installed-globally": "^0.3.1",
-	"is-npm": "^4.0.0",
-	"is-yarn-global": "^0.3.0",
-	"latest-version": "^5.0.0",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-npm": "^4.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
         "pupa": "^2.0.1",
-	"semver-diff": "^3.1.1",
-	"xdg-basedir": "^4.0.0"
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-	"ansi-styles": {
-	  "version": "4.2.1",
-	  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-	  "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-	  "dev": true,
-	  "requires": {
-	    "@types/color-name": "^1.1.1",
-	    "color-convert": "^2.0.1"
-	  }
-	},
-	"chalk": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-	  "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-	  "dev": true,
-	  "requires": {
-	    "ansi-styles": "^4.1.0",
-	    "supports-color": "^7.1.0"
-	  }
-	},
-	"color-convert": {
-	  "version": "2.0.1",
-	  "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-	  "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-	  "dev": true,
-	  "requires": {
-	    "color-name": "~1.1.4"
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-	"color-name": {
-	  "version": "1.1.4",
-	  "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-	  "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-	  "dev": true
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
         },
-	"has-flag": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-	  "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-	  "dev": true
-	},
-	"supports-color": {
-	  "version": "7.1.0",
-	  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-	  "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-	  "dev": true,
-	  "requires": {
-	    "has-flag": "^4.0.0"
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -9867,7 +9867,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-	"prepend-http": "^1.0.1"
+        "prepend-http": "^1.0.1"
       }
     },
     "url-to-options": {
@@ -9921,7 +9921,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-	"builtins": "^1.0.3"
+        "builtins": "^1.0.3"
       }
     },
     "validator": {
@@ -9950,12 +9950,12 @@
       "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
       "dev": true,
       "requires": {
-	"clone": "^2.1.1",
-	"clone-buffer": "^1.0.0",
-	"clone-stats": "^1.0.0",
-	"cloneable-readable": "^1.0.0",
-	"remove-trailing-separator": "^1.0.1",
-	"replace-ext": "^1.0.0"
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
       }
     },
     "vinyl-file": {
@@ -9964,52 +9964,52 @@
       "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
       "dev": true,
       "requires": {
-	"graceful-fs": "^4.1.2",
-	"pify": "^2.3.0",
-	"pinkie-promise": "^2.0.0",
-	"strip-bom": "^2.0.0",
-	"strip-bom-stream": "^2.0.0",
-	"vinyl": "^1.1.0"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^1.1.0"
       },
       "dependencies": {
-	"clone": {
-	  "version": "1.0.4",
-	  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-	  "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-	  "dev": true
-	},
-	"clone-stats": {
-	  "version": "0.0.1",
-	  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-	  "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-	  "dev": true
-	},
-	"replace-ext": {
-	  "version": "0.0.1",
-	  "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-	  "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-	  "dev": true
-	},
-	"strip-bom": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-	  "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-	  "dev": true,
-	  "requires": {
-	    "is-utf8": "^0.2.0"
-	  }
-	},
-	"vinyl": {
-	  "version": "1.2.0",
-	  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-	  "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-	  "dev": true,
-	  "requires": {
-	    "clone": "^1.0.0",
-	    "clone-stats": "^0.0.1",
-	    "replace-ext": "0.0.1"
-	  }
-	}
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+          "dev": true
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
       }
     },
     "which": {
@@ -10046,47 +10046,47 @@
       "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dev": true,
       "requires": {
-	"string-width": "^4.0.0"
+        "string-width": "^4.0.0"
       },
       "dependencies": {
-	"ansi-regex": {
-	  "version": "5.0.0",
-	  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-	  "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-	  "dev": true
-	},
-	"emoji-regex": {
-	  "version": "8.0.0",
-	  "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-	  "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-	  "dev": true
-	},
-	"is-fullwidth-code-point": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-	  "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-	  "dev": true
-	},
-	"string-width": {
-	  "version": "4.2.0",
-	  "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-	  "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-	  "dev": true,
-	  "requires": {
-	    "emoji-regex": "^8.0.0",
-	    "is-fullwidth-code-point": "^3.0.0",
-	    "strip-ansi": "^6.0.0"
-	  }
-	},
-	"strip-ansi": {
-	  "version": "6.0.0",
-	  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-	  "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-	  "dev": true,
-	  "requires": {
-	    "ansi-regex": "^5.0.0"
-	  }
-	}
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "wikidata-sdk": {
@@ -10120,23 +10120,23 @@
       "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
       "dev": true,
       "requires": {
-	"p-finally": "^1.0.0",
-	"p-try": "^2.1.0",
-	"pify": "^4.0.1"
+        "p-finally": "^1.0.0",
+        "p-try": "^2.1.0",
+        "pify": "^4.0.1"
       },
       "dependencies": {
-	"p-try": {
-	  "version": "2.2.0",
-	  "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-	  "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-	  "dev": true
-	},
-	"pify": {
-	  "version": "4.0.1",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-	  "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-	  "dev": true
-	}
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "wkx": {
@@ -10218,9 +10218,9 @@
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
       "requires": {
-	"graceful-fs": "^4.1.11",
-	"imurmurhash": "^0.1.4",
-	"slide": "^1.1.5"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "ws": {
@@ -10281,6 +10281,29 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+    },
+    "yaml": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.8.2.tgz",
+      "integrity": "sha512-omakb0d7FjMo3R1D2EbTKVIk6dAVLRxFXdLZMEUToeAvuqgG/YuHMuQOZ5fgk+vQ8cx+cnGKwyg+8g8PNT0xQg==",
+      "requires": {
+        "@babel/runtime": "^7.8.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+        }
+      }
     },
     "yargs": {
       "version": "13.3.0",
@@ -10409,90 +10432,90 @@
       "integrity": "sha512-BbJeEna23Qx90fBiJt1awcZ9okfPY/rP3xZYsk1rD3x8LuQgpo4BfegPvQT1sqqh2+gYVZmYZMv5pS8+Muyr9Q==",
       "dev": true,
       "requires": {
-	"chalk": "^2.4.1",
-	"cross-spawn": "^6.0.5",
-	"debug": "^3.1.0",
-	"diff": "^3.5.0",
-	"escape-string-regexp": "^1.0.2",
-	"globby": "^8.0.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "diff": "^3.5.0",
+        "escape-string-regexp": "^1.0.2",
+        "globby": "^8.0.1",
         "grouped-queue": "^1.0.0",
-	"inquirer": "^6.0.0",
-	"is-scoped": "^1.0.0",
-	"lodash": "^4.17.10",
-	"log-symbols": "^2.2.0",
-	"mem-fs": "^1.1.0",
-	"strip-ansi": "^4.0.0",
-	"text-table": "^0.2.0",
-	"untildify": "^3.0.3"
+        "inquirer": "^6.0.0",
+        "is-scoped": "^1.0.0",
+        "lodash": "^4.17.10",
+        "log-symbols": "^2.2.0",
+        "mem-fs": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "text-table": "^0.2.0",
+        "untildify": "^3.0.3"
       },
       "dependencies": {
-	"ansi-regex": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-	  "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-	  "dev": true
-	},
-	"arrify": {
-	  "version": "1.0.1",
-	  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-	  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-	  "dev": true
-	},
-	"dir-glob": {
-	  "version": "2.0.0",
-	  "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-	  "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-	  "dev": true,
-	  "requires": {
-	    "arrify": "^1.0.1",
-	    "path-type": "^3.0.0"
-	  }
-	},
-	"globby": {
-	  "version": "8.0.2",
-	  "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-	  "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
-	  "dev": true,
-	  "requires": {
-	    "array-union": "^1.0.1",
-	    "dir-glob": "2.0.0",
-	    "fast-glob": "^2.0.2",
-	    "glob": "^7.1.2",
-	    "ignore": "^3.3.5",
-	    "pify": "^3.0.0",
-	    "slash": "^1.0.0"
-	  }
-	},
-	"ignore": {
-	  "version": "3.3.10",
-	  "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-	  "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-	  "dev": true
-	},
-	"path-type": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-	  "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-	  "dev": true,
-	  "requires": {
-	    "pify": "^3.0.0"
-	  }
-	},
-	"pify": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-	  "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-	  "dev": true
-	},
-	"strip-ansi": {
-	  "version": "4.0.0",
-	  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-	  "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-	  "dev": true,
-	  "requires": {
-	    "ansi-regex": "^3.0.0"
-	  }
-	}
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "dir-glob": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+          "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "path-type": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "2.0.0",
+            "fast-glob": "^2.0.2",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "yeoman-generator": {
@@ -10501,125 +10524,125 @@
       "integrity": "sha512-Hq65rLqMNCS0h0n1yakSZjHsEZHm0ZpOM02Nja6O03s2k5WHvAhGOx7uxs93vrJv62zFrJtD9e9mVhgoVbi7CQ==",
       "dev": true,
       "requires": {
-	"async": "^2.6.2",
-	"chalk": "^2.4.2",
-	"cli-table": "^0.3.1",
-	"cross-spawn": "^6.0.5",
-	"dargs": "^6.1.0",
-	"dateformat": "^3.0.3",
-	"debug": "^4.1.1",
-	"diff": "^4.0.1",
-	"error": "^7.0.2",
-	"find-up": "^3.0.0",
-	"github-username": "^3.0.0",
-	"istextorbinary": "^2.5.1",
-	"lodash": "^4.17.11",
-	"make-dir": "^3.0.0",
-	"mem-fs-editor": "^6.0.0",
-	"minimist": "^1.2.0",
-	"pretty-bytes": "^5.2.0",
-	"read-chunk": "^3.2.0",
-	"read-pkg-up": "^5.0.0",
-	"rimraf": "^2.6.3",
-	"run-async": "^2.0.0",
-	"shelljs": "^0.8.3",
-	"text-table": "^0.2.0",
-	"through2": "^3.0.1",
-	"yeoman-environment": "^2.3.4"
+        "async": "^2.6.2",
+        "chalk": "^2.4.2",
+        "cli-table": "^0.3.1",
+        "cross-spawn": "^6.0.5",
+        "dargs": "^6.1.0",
+        "dateformat": "^3.0.3",
+        "debug": "^4.1.1",
+        "diff": "^4.0.1",
+        "error": "^7.0.2",
+        "find-up": "^3.0.0",
+        "github-username": "^3.0.0",
+        "istextorbinary": "^2.5.1",
+        "lodash": "^4.17.11",
+        "make-dir": "^3.0.0",
+        "mem-fs-editor": "^6.0.0",
+        "minimist": "^1.2.0",
+        "pretty-bytes": "^5.2.0",
+        "read-chunk": "^3.2.0",
+        "read-pkg-up": "^5.0.0",
+        "rimraf": "^2.6.3",
+        "run-async": "^2.0.0",
+        "shelljs": "^0.8.3",
+        "text-table": "^0.2.0",
+        "through2": "^3.0.1",
+        "yeoman-environment": "^2.3.4"
       },
       "dependencies": {
-	"debug": {
-	  "version": "4.1.1",
-	  "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-	  "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-	  "dev": true,
-	  "requires": {
-	    "ms": "^2.1.1"
-	  }
-	},
-	"diff": {
-	  "version": "4.0.2",
-	  "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-	  "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-	  "dev": true
-	},
-	"find-up": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-	  "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-	  "dev": true,
-	  "requires": {
-	    "locate-path": "^3.0.0"
-	  }
-	},
-	"locate-path": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-	  "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-	  "dev": true,
-	  "requires": {
-	    "p-locate": "^3.0.0",
-	    "path-exists": "^3.0.0"
-	  }
-	},
-	"p-limit": {
-	  "version": "2.2.2",
-	  "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-	  "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-	  "dev": true,
-	  "requires": {
-	    "p-try": "^2.0.0"
-	  }
-	},
-	"p-locate": {
-	  "version": "3.0.0",
-	  "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-	  "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-	  "dev": true,
-	  "requires": {
-	    "p-limit": "^2.0.0"
-	  }
-	},
-	"p-try": {
-	  "version": "2.2.0",
-	  "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-	  "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-	  "dev": true
-	},
-	"parse-json": {
-	  "version": "5.0.0",
-	  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-	  "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-	  "dev": true,
-	  "requires": {
-	    "@babel/code-frame": "^7.0.0",
-	    "error-ex": "^1.3.1",
-	    "json-parse-better-errors": "^1.0.1",
-	    "lines-and-columns": "^1.1.6"
-	  }
-	},
-	"read-pkg": {
-	  "version": "5.2.0",
-	  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-	  "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-	  "dev": true,
-	  "requires": {
-	    "@types/normalize-package-data": "^2.4.0",
-	    "normalize-package-data": "^2.5.0",
-	    "parse-json": "^5.0.0",
-	    "type-fest": "^0.6.0"
-	  }
-	},
-	"read-pkg-up": {
-	  "version": "5.0.0",
-	  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
-	  "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
-	  "dev": true,
-	  "requires": {
-	    "find-up": "^3.0.0",
-	    "read-pkg": "^5.0.0"
-	  }
-	}
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+          "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^5.0.0"
+          }
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,12 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
+    "@types/mocha": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.12.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -584,15 +584,15 @@
       }
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
-      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
     "after": {
@@ -3655,53 +3655,97 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.16.0.tgz",
-      "integrity": "sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.9.1",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.3",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.2.2",
-        "js-yaml": "^3.13.0",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
         "table": "^5.2.3",
-        "text-table": "^0.2.0"
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          }
+        },
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "debug": {
@@ -3713,14 +3757,180 @@
             "ms": "^2.1.1"
           }
         },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+          "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "escape-string-regexp": "^1.0.5"
           }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+          "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^3.0.0",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.4.0",
+            "rxjs": "^6.5.3",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+          "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
         }
       }
     },
@@ -3887,9 +4097,9 @@
       "dev": true
     },
     "eslint-scope": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -3912,14 +4122,14 @@
       "dev": true
     },
     "espree": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
-      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -3929,9 +4139,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -5327,10 +5537,21 @@
       }
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
     },
     "globby": {
       "version": "9.2.0",
@@ -7755,12 +7976,6 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -9910,6 +10125,12 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "test": "npm run eslint && npm run mocha",
+    "quicktest": "mocha test/hooks --recursive && mocha test/logic --recursive && mocha test/models --recursive && mocha test/util --recursive",
     "eslint": "eslint src/. test/. --config .eslintrc.json --fix",
     "start": "node src/",
     "dev": "nodemon src/",
@@ -110,6 +111,7 @@
   },
   "devDependencies": {
     "@feathersjs/cli": "^4.3.0",
+    "@types/mocha": "^7.0.2",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-standard": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "truncatise": "0.0.7",
     "wikidata-sdk": "^5.15.10",
     "winston": "^2.4.4",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.4.19",
+    "yaml": "^1.8.2"
   },
   "devDependencies": {
     "@feathersjs/cli": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   "devDependencies": {
     "@feathersjs/cli": "^4.3.0",
     "@types/mocha": "^7.0.2",
-    "eslint": "^5.16.0",
+    "eslint": "6.8",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-standard": "^11.0.0",
     "eslint-config-strongloop": "^2.1.0",

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -171,7 +171,7 @@ const SolrMappings = Object.freeze({
       },
       textReuseClusterDayDelta: {
         type: 'range',
-        field: 'day_delta_f',
+        field: 'day_delta_i',
         ...getRangeFacetParametersWithDefault('tr_clusters', 'textReuseClusterDayDelta', 10, {
           end: 100,
           start: 0,

--- a/src/models/index.d.ts
+++ b/src/models/index.d.ts
@@ -1,0 +1,13 @@
+
+export type FilterContext = 'include' | 'exclude';
+export type FilterOperator = 'AND' | 'OR';
+export type FilterType = string;
+export type FilterPrecision = 'exact' | 'partial' | 'fuzzy' | 'soft';
+
+export interface Filter {
+  context?: FilterContext;
+  op?: FilterOperator;
+  type: FilterType;
+  precision?: FilterPrecision;
+  q?: string | string[];
+}

--- a/src/services/ngram-trends/logic/solrQuery.js
+++ b/src/services/ngram-trends/logic/solrQuery.js
@@ -7,6 +7,7 @@ const {
   filtersToQueryAndVariables,
   ContentLanguages,
 } = require('../../../util/solr');
+const { SolrNamespaces } = require('../../../solr');
 
 const {
   getFacetsFromSolrResponse,
@@ -44,7 +45,7 @@ const getStatsFieldString = (languageCode, unigram) =>
  * @return {object} a POST JSON payload for SOLR search endpoint.
  */
 function unigramTrendsRequestToSolrQuery(unigram, filters, facets = [], timeInterval = 'year') {
-  const { query, variables } = filtersToQueryAndVariables(filters);
+  const { query, variables } = filtersToQueryAndVariables(filters, SolrNamespaces.Search);
   const timeIntervalField = TimeIntervalsFilelds[timeInterval];
 
   const facetPivots = ContentLanguages

--- a/src/services/search-facets/search-facets.hooks.js
+++ b/src/services/search-facets/search-facets.hooks.js
@@ -8,6 +8,7 @@ const {
 const { filtersToSolrQuery } = require('../../hooks/search');
 const { resolveCollections } = require('../../hooks/resolvers');
 const { SolrMappings } = require('../../data/constants');
+const { SolrNamespaces } = require('../../solr');
 
 const DefaultIndex = 'search';
 const SupportedIndexes = Object.keys(SolrMappings);
@@ -42,6 +43,7 @@ module.exports = {
       validateEach('filters', eachFilterValidator),
       filtersToSolrQuery({
         overrideOrderBy: false,
+        solrIndexProvider: context => context.params.query.index || SolrNamespaces.Search,
       }),
       queryWithCommonParams(),
     ],

--- a/src/services/search-queries-comparison/search-queries-comparison.class.js
+++ b/src/services/search-queries-comparison/search-queries-comparison.class.js
@@ -9,6 +9,7 @@ const {
   getTotalFromSolrResponse,
 } = require('../search/search.extractors');
 const { sameTypeFiltersToQuery } = require('../../util/solr');
+const { SolrNamespaces } = require('../../solr');
 
 // TODO: Do we need to make it configurable in request?
 const DefaultSolrFieldsFilter = ['id', 'pp_plain:[json]', 'lg_s'].join(',');
@@ -32,7 +33,8 @@ function intersectionRequestToSolrQuery(request) {
   const allFilters = flatten(queries.map(({ filters }) => filters));
 
   const filtersGroupsByType = values(groupBy(allFilters, 'type'));
-  const solrQueries = uniq(filtersGroupsByType.map(sameTypeFiltersToQuery));
+  const solrQueries = uniq(filtersGroupsByType
+    .map(f => sameTypeFiltersToQuery(f, SolrNamespaces.Search)));
 
   const q = solrQueries.join(' AND ');
   const fl = DefaultSolrFieldsFilter;

--- a/src/services/text-reuse-clusters/text-reuse-clusters.class.js
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.class.js
@@ -16,6 +16,7 @@ const {
 } = require('../../logic/textReuse/solr');
 const { parseOrderBy } = require('../../util/queryParameters');
 const { sameTypeFiltersToQuery } = require('../../util/solr');
+const { SolrNamespaces } = require('../../solr');
 
 function buildResponseClusters(clusters, clusterIdsAndText) {
   const clustersById = mapValues(groupBy(clusters, 'id'), v => v[0]);
@@ -30,7 +31,8 @@ const deserializeFilters = serializedFilters => protobuf
 
 function filtersToSolrQueries(filters) {
   const filtersGroupsByType = values(groupBy(filters, 'type'));
-  return uniq(filtersGroupsByType.map(sameTypeFiltersToQuery));
+  return uniq(filtersGroupsByType
+    .map(f => sameTypeFiltersToQuery(f, SolrNamespaces.TextReusePassages)));
 }
 
 const OrderByKeyToField = {

--- a/src/util/solr/filterReducers.js
+++ b/src/util/solr/filterReducers.js
@@ -46,8 +46,8 @@ const fullyEscapeValue = value => escapeValue(value).replace(/"/g, d => `\\${d}`
 /**
  * Convert filter to a Solr request.
  * @param {string} value filter value
- * @param {*} solrFields Solr fields to apply the value to.
- * @param {*} precision filter precision.
+ * @param {string[]} solrFields Solr fields to apply the value to.
+ * @param {import('../../models').FilterPrecision} precision filter precision.
  */
 const getStringQueryWithFields = (value, solrFields, precision) => {
   let q = value.trim();
@@ -85,15 +85,15 @@ const getStringQueryWithFields = (value, solrFields, precision) => {
 
 /**
  * String type filter handler
- * @param {object[]} filters
+ * @param {import('../../models').Filter[]} filters
  * @param {string | string[] | object} field
  * @return {string} solr query
  */
 const reduceStringFiltersToSolr = (filters, field) => {
+  const languages = SolrSupportedLanguages;
   const items = filters.map(({
     q,
     op = 'OR',
-    langs: languages = SolrSupportedLanguages,
     precision,
     context,
   }, index) => {

--- a/src/util/solr/filterReducers.js
+++ b/src/util/solr/filterReducers.js
@@ -217,7 +217,21 @@ const FiltersHandlers = Object.freeze({
   regex: reduceRegexFiltersToSolr,
 });
 
-const filtersToSolr = (type, filters, solrNamespace) => {
+/**
+ * Convert a set of filters of the same type to a SOLR query string.
+ * Types are defined in `solrFilters.yml` for the corresponding namespace
+ *
+ * @param {import('../../models').Filter[]} filters list of filters of the same type.
+ * @param {string} solrNamespace namespace (index) this filter type belongs to.
+ *
+ * @returns {string} a SOLR query string that can be wrapped into a `filter()` statement.
+ */
+const filtersToSolr = (filters, solrNamespace) => {
+  if (filters.length < 1) throw new Error('At least one filter must be provided');
+  const types = [...new Set(filters.map(({ type }) => type))];
+  if (types.length > 1) throw new Error(`Filters must be of the same type. Found types: "${types}"`);
+  const type = types[0];
+
   const filtersRules = filtersConfig.indexes[solrNamespace]
     ? filtersConfig.indexes[solrNamespace].filters
     : {};

--- a/src/util/solr/filterReducers.js
+++ b/src/util/solr/filterReducers.js
@@ -1,3 +1,4 @@
+// @ts-check
 const YAML = require('yaml');
 const { readFileSync } = require('fs');
 
@@ -14,8 +15,7 @@ const getValueWithFields = (value, fields) => {
 const RangeValueRegex = /^\s*\d+\s+TO\s+\d+\s*$/;
 
 const reduceNumericRangeFilters = (filters, field) => {
-  return filters
-  .reduce((sq, filter) => {
+  const items = filters.reduce((sq, filter) => {
     let q; // q is in the form array ['1 TO 10', '20 TO 30'] (OR condition)
     // or simple string '1 TO X';
     if (Array.isArray(filter.q)) {
@@ -34,39 +34,26 @@ const reduceNumericRangeFilters = (filters, field) => {
     }
     sq.push(q);
     return sq;
-  }, []).join(' AND ');
+  }, []);
+
+  return items.join(' AND ');
 };
 
 const SolrSupportedLanguages = ['en', 'fr', 'de'];
 
-const reduceStringFiltersToSolr = (filters, field) => {
-  let fields = [];
-  if (typeof field === 'string') fields = [field];
-  else if (Array.isArray(field)) fields = field;
-  else if (field.prefix != null) fields = SolrSupportedLanguages.map(lang => `${field.prefix}${lang}`);
-  else throw new Error(`Unknown type of Solr field: ${JSON.stringify(field)}`);
+const fullyEscapeValue = value => escapeValue(value).replace(/"/g, d => `\\${d}`);
 
-  // reduce the string in filters to final SOLR query `sq`
-  return filters.reduce((sq, filter) => {
-    let q;
-    if (Array.isArray(filter.q)) {
-      if (filter.q.length !== 1) {
-        throw new Error(`"string" filter rule supports only single element arrays in "q": ${JSON.stringify(filter.q)}`);
-      }
-      q = filter.q[0].trim();
-    } else {
-      q = filter.q.trim();
-    }
-
-    q = q.replace(/"/g, ' ');
-    // const isExact = /^"[^"]+"$/.test(q);
+/**
+ * Convert filter to a Solr request.
+ * @param {string} value filter value
+ * @param {*} solrFields Solr fields to apply the value to.
+ * @param {*} precision filter precision.
+ */
+const getStringQueryWithFields = (value, solrFields, precision) => {
+  let q = value.trim();
   const hasMultipleWords = q.split(/\s/).length > 1;
   const isExact = q.match(/^"(.*)"(~[12345])?$/);
   const isFuzzy = q.match(/^(.*)~([12345])$/);
-  // escape unwanted values
-  // console.log(filter);
-  // console.log('isExact', isExact);
-  // console.log('isFuzzy', isFuzzy);
   if (isExact && isFuzzy) {
     q = `"${fullyEscapeValue(isExact[1])}"${isExact[2]}`;
   } else if (isExact) {
@@ -76,70 +63,80 @@ const reduceStringFiltersToSolr = (filters, field) => {
   } else {
     // use filter properties if set
     q = fullyEscapeValue(q);
-    if (filter.precision === 'soft') {
+    if (precision === 'soft') {
       q = `(${q.split(/\s+/g).join(' OR ')})`;
-    } else if (filter.precision === 'fuzzy') {
+    } else if (precision === 'fuzzy') {
       // "richard chase"~1
       q = `"${q.split(/\s+/g).join(' ')}"~1`;
-    } else if (filter.precision === 'exact') {
+    } else if (precision === 'exact') {
       q = `"${q}"`;
     } else if (hasMultipleWords) {
       // text:"Richard Chase"
+      q = q.replace(/"/g, ' ');
+      q = `"${q.split(/\s+/g).join(' ')}"`;
       q = `(${q.split(/\s+/g).join(' ')})`;
     }
   }
 
-    const ql = fields.map(f => `${f}:${q}`);
-    q = ql.length > 1
-      ? `(${ql.join(' OR ')})`
-      : ql[0];
-
-    // // q multiplied for languages :(
-    // if (languages.length) {
-    //   const ql = (filter.langs || languages).map(lang => `${field}_${lang}:${q}`);
-
-    //   if (ql.length > 1) {
-    //     q = `(${ql.join(' OR ')})`;
-    //   } else {
-    //     q = ql[0];
-    //   }
-    // } else {
-    //   q = `${field}:${q}`;
-    // }
-
-  if (Array.isArray(filter.q)) {
-    qq = filter.q.map(value => getStringQueryWithFields(
-      value,
-      field,
-      filter.langs || languages,
-      filter,
-    )).join(` ${op} `);
-    qq = `(${qq})`;
-  } else {
-    qq = getStringQueryWithFields(
-      filter.q,
-      field,
-      filter.langs || languages,
-      filter,
-    );
-  }
-  if (filter.context === 'exclude') {
-    qq = sq.length > 0 ? `NOT (${qq})` : `*:* AND NOT (${qq})`;
-  }
-  sq.push(qq);
-  return sq;
-}, []).join(' AND ');
+  const items = solrFields.map(f => `${f}:${q}`);
+  const statement = items.join(' OR ');
+  return items.length > 1 ? `(${statement})` : statement;
 };
 
-const reduceDaterangeFiltersToSolr = filters => filters
-  .reduce((sq, filter) => {
+/**
+ * String type filter handler
+ * @param {object[]} filters
+ * @param {string | string[] | object} field
+ * @return {string} solr query
+ */
+const reduceStringFiltersToSolr = (filters, field) => {
+  const items = filters.map(({
+    q,
+    op = 'OR',
+    langs: languages = SolrSupportedLanguages,
+    precision,
+    context,
+  }, index) => {
+    let fields = [];
+
+    if (typeof field === 'string') fields = [field];
+    else if (Array.isArray(field)) fields = field;
+    else if (field.prefix != null) fields = languages.map(lang => `${field.prefix}${lang}`);
+    else throw new Error(`Unknown type of Solr field: ${JSON.stringify(field)}`);
+
+    const queryList = Array.isArray(q) ? q : [q];
+
+    let transformedQuery = queryList
+      .map(value => getStringQueryWithFields(value, fields, precision))
+      // @ts-ignore
+      .flat()
+      .join(` ${op} `);
+
+    if (context === 'exclude') {
+      transformedQuery = index > 0 ? `NOT (${transformedQuery})` : `*:* AND NOT (${transformedQuery})`;
+    }
+
+    return queryList.length > 1 ? `(${transformedQuery})` : transformedQuery;
+  });
+
+  // @ts-ignore
+  return items.flat().join(' AND ');
+};
+
+const DateRangeValueRegex = /^\s*[TZ:\d-]+\s+TO\s+[TZ:\d-]+\s*$/;
+
+const reduceDaterangeFiltersToSolr = (filters, field, rule) => {
+  const items = filters.reduce((sq, filter) => {
     let q;
     if (Array.isArray(filter.q)) {
-      q = `${filter.q.map(d => `meta_date_dt:[${d}]`).join(' OR ')}`;
+      q = `${filter.q.map(d => `${field}:[${d}]`).join(' OR ')}`;
       if (filter.q.length > 1) {
         q = `(${q})`;
       }
     } else {
+      if (!filter.q.match(DateRangeValueRegex)) {
+        throw new Error(`"${rule}" filter rule: unknown value encountered in "q": ${filter.q}`);
+      }
       q = `meta_date_dt:[${filter.q}]`;
     }
     if (filter.context === 'exclude') {
@@ -147,7 +144,9 @@ const reduceDaterangeFiltersToSolr = filters => filters
     }
     sq.push(q);
     return sq;
-  }, []).join(' AND ');
+  }, []);
+  return items.join(' AND ');
+};
 
 const reduceFiltersToSolr = (filters, field) => filters.reduce((sq, filter) => {
   let qq = '';
@@ -166,9 +165,26 @@ const reduceFiltersToSolr = (filters, field) => filters.reduce((sq, filter) => {
   return sq;
 }, []).join(' AND ');
 
-const reduceRegexFiltersToSolr = filters => filters.reduce((reduced, query) => {
+const reduceRegexFiltersToSolr = (filters, field) => {
+  let fields = [];
+  if (typeof field === 'string') fields = [field];
+  else if (Array.isArray(field)) fields = field;
+  else if (field.prefix != null) fields = SolrSupportedLanguages.map(lang => `${field.prefix}${lang}`);
+  else throw new Error(`Unknown type of Solr field: ${JSON.stringify(field)}`);
+
+  return filters.reduce((reduced, { q, op = 'OR' }) => {
   // cut regexp at any . not preceded by an escape sign.
-  const q = query.q
+    let queryString;
+    if (Array.isArray(q)) {
+      if (q.length !== 1) {
+        throw new Error(`"regex" filter rule supports only single element arrays in "q": ${JSON.stringify(q)}`);
+      }
+      queryString = q[0].trim();
+    } else {
+      queryString = q.trim();
+    }
+
+    const query = queryString
   // get rid of first / and last /
     .replace(/^\/|\/$/g, '')
   // split on point or spaces
@@ -176,9 +192,10 @@ const reduceRegexFiltersToSolr = filters => filters.reduce((reduced, query) => {
   // filterout empty stuff
     .filter(d => d.length)
   // rebuild;
-    .map(d => `content_txt_fr:/${d}/`);
-  return reduced.concat(q);
+      .map(d => fields.map(f => `${f}:/${d}/`).join(` ${op} `));
+    return reduced.concat(query.map(v => (fields.length > 1 ? `(${v})` : v)));
 }, []).join(' AND ');
+};
 
 const minLengthOneHandler = (filters, field, filterRule) => {
   if (typeof field !== 'string') throw new Error(`"${filterRule}" supports only "string" fields`);
@@ -195,6 +212,9 @@ const FiltersHandlers = Object.freeze({
   numericRange: reduceNumericRangeFilters,
   boolean: booleanHandler,
   string: reduceStringFiltersToSolr,
+  dateRange: reduceDaterangeFiltersToSolr,
+  value: reduceFiltersToSolr,
+  regex: reduceRegexFiltersToSolr,
 });
 
 const filtersToSolr = (type, filters, solrNamespace) => {
@@ -208,81 +228,9 @@ const filtersToSolr = (type, filters, solrNamespace) => {
   if (handler == null) throw new Error(`Could not find handler for rule ${filterRules.rule}`);
 
   return handler(filters, filterRules.field, filterRules.rule);
-
-  // switch (type) {
-  //   case 'hasTextContents':
-  //     return config.solr.queries.hasTextContents;
-  //   case 'ocrQuality':
-  //     return reduceNumericRangeFilters(filters, 'ocrqa_f');
-  //   case 'contentLength':
-  //     return reduceNumericRangeFilters(filters, 'content_length_i');
-  //   case 'isFront':
-  //     return 'front_b:1';
-  //   case 'string':
-  //     return reduceStringFiltersToSolr(filters, 'content_txt');
-  //   case 'title':
-  //     return reduceStringFiltersToSolr(filters, 'title_txt');
-  //   case 'daterange':
-  //     return reduceDaterangeFiltersToSolr(filters);
-  //   case 'uid':
-  //     return reduceFiltersToSolr(filters, 'id');
-  //   case 'accessRight':
-  //     return reduceFiltersToSolr(filters, 'access_right_s');
-  //   case 'partner':
-  //     return reduceFiltersToSolr(filters, 'meta_partnerid_s');
-  //   case 'language':
-  //     return reduceFiltersToSolr(filters, 'lg_s');
-  //   case 'page':
-  //     return reduceFiltersToSolr(filters, 'page_id_ss');
-  //   case 'collection':
-  //     return reduceFiltersToSolr(filters, 'ucoll_ss');
-  //   case 'issue':
-  //     return reduceFiltersToSolr(filters, 'meta_issue_id_s');
-  //   case 'newspaper':
-  //     return reduceFiltersToSolr(filters, 'meta_journal_s');
-  //   case 'topic':
-  //     return reduceFiltersToSolr(filters, 'topics_dpfs');
-  //   case 'year':
-  //     return reduceFiltersToSolr(filters, 'meta_year_i');
-  //   case 'type':
-  //     return reduceFiltersToSolr(filters, 'item_type_s');
-  //   case 'country':
-  //     return reduceFiltersToSolr(filters, 'meta_country_code_s');
-  //   case 'mention':
-  //     return reduceFiltersToSolr(filters, ['pers_mentions', 'loc_mentions']);
-  //   case 'entity':
-  //     return reduceFiltersToSolr(filters, ['pers_entities_dpfs', 'loc_entities_dpfs']);
-  //   case 'person':
-  //     return reduceFiltersToSolr(filters, 'pers_entities_dpfs');
-  //   case 'location':
-  //     return reduceFiltersToSolr(filters, 'loc_entities_dpfs');
-  //   case 'topicmodel':
-  //     return reduceFiltersToSolr(filters, 'tp_model_s');
-  //   case 'topic-string':
-  //     return reduceStringFiltersToSolr(filters, 'topic_suggest', []);
-  //   case 'entity-string':
-  //     return reduceStringFiltersToSolr(filters, 'entitySuggest', []);
-  //   case 'entity-type':
-  //     return reduceFiltersToSolr(filters, 't_s');
-  //   case 'regex':
-  //     return reduceRegexFiltersToSolr(filters);
-  //   case 'textReuseClusterSize':
-  //     return reduceNumericRangeFilters(filters, 'cluster_size_l');
-  //   // TODO: the two fields below are for TR passages,
-  //   // the names for clusters are different. This function should take
-  //   // index name as a parameter.
-  //   case 'textReuseClusterLexicalOverlap':
-  //     return reduceNumericRangeFilters(filters, 'cluster_lex_overlap_d');
-  //   case 'textReuseClusterDayDelta':
-  //     return reduceNumericRangeFilters(filters, 'cluster_day_delta_i');
-  //   default:
-  //     throw new Error(`Unknown filter type in namespace "${solrNamespace}": ${type}`);
-  // }
 };
 
 module.exports = {
   filtersToSolr,
-  reduceFiltersToSolr,
-  reduceRegexFiltersToSolr,
   escapeValue,
 };

--- a/src/util/solr/filterReducers.js
+++ b/src/util/solr/filterReducers.js
@@ -19,14 +19,14 @@ const reduceNumericRangeFilters = (filters, field) => {
     let q; // q is in the form array ['1 TO 10', '20 TO 30'] (OR condition)
     // or simple string '1 TO X';
     if (Array.isArray(filter.q)) {
-        if (filter.q.length !== 2 || !filter.q.every(v => Number.isFinite(parseInt(v, 10)))) {
-          throw new Error(`"numericRange" filter rule: unknown values encountered in "q": ${filter.q}`);
-        }
+      if (filter.q.length !== 2 || !filter.q.every(v => Number.isFinite(parseInt(v, 10)))) {
+        throw new Error(`"numericRange" filter rule: unknown values encountered in "q": ${filter.q}`);
+      }
       q = `${field}:[${filter.q[0]} TO ${filter.q[1]}]`;
     } else {
-        if (!filter.q.match(RangeValueRegex)) {
-          throw new Error(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`);
-        }
+      if (!filter.q.match(RangeValueRegex)) {
+        throw new Error(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`);
+      }
       q = `${field}:[${filter.q}]`;
     }
     if (filter.context === 'exclude') {
@@ -185,16 +185,16 @@ const reduceRegexFiltersToSolr = (filters, field) => {
     }
 
     const query = queryString
-  // get rid of first / and last /
-    .replace(/^\/|\/$/g, '')
-  // split on point or spaces
-    .split(/\\?\.[*+]/)
-  // filterout empty stuff
-    .filter(d => d.length)
-  // rebuild;
+    // get rid of first / and last /
+      .replace(/^\/|\/$/g, '')
+    // split on point or spaces
+      .split(/\\?\.[*+]/)
+    // filterout empty stuff
+      .filter(d => d.length)
+    // rebuild;
       .map(d => fields.map(f => `${f}:/${d}/`).join(` ${op} `));
     return reduced.concat(query.map(v => (fields.length > 1 ? `(${v})` : v)));
-}, []).join(' AND ');
+  }, []).join(' AND ');
 };
 
 const minLengthOneHandler = (filters, field, filterRule) => {

--- a/src/util/solr/index.js
+++ b/src/util/solr/index.js
@@ -2,6 +2,7 @@
 const assert = require('assert');
 const { uniq, includes, groupBy } = require('lodash');
 const { filtersToSolr, escapeValue } = require('./filterReducers');
+const { SolrNamespaces } = require('../../solr');
 
 /**
  * Languages that have content indexes in Solr.
@@ -47,14 +48,17 @@ const reduceFiltersToVars = filters => filters.reduce((sq, filter) => {
 /**
  * Return a section of the Solr query based on the filters **of the same type**.
  * @param {array} filters a list of filters (`src/schema/search/filter.json`).
+ * @param {string} solrNamespace index to use (see `src/solr.js` - `SolrNamespaces`)
  * @return {string} a Solr query.
  */
-function sameTypeFiltersToQuery(filters) {
+function sameTypeFiltersToQuery(filters, solrNamespace = SolrNamespaces.Search) {
+  assert.ok(Object.values(SolrNamespaces).includes(solrNamespace), `Unknown Solr namespace: ${solrNamespace}`);
+
   const filtersTypes = uniq(filters.map(f => f.type));
   assert.equal(filtersTypes.length, 1, `Filters must be of the same type but they are of: ${filtersTypes.join(', ')}`);
 
   const type = filtersTypes[0];
-  const statement = filtersToSolr(type, filters);
+  const statement = filtersToSolr(type, filters, solrNamespace);
 
   return includes(NON_FILTERED_FIELDS, type)
     ? statement
@@ -70,10 +74,12 @@ function sameTypeFiltersToQuery(filters) {
 /**
  * Return Solr query string and referenced variables for a set of filters.
  * @param {Array<object>} filters a list of filters of type `src/schema/search/filter.json`.
- *
+ * @param {string} solrNamespace index to use (see `src/solr.js` - `SolrNamespaces`)
  * @return {SolrQueryAndVariables}
  */
-function filtersToQueryAndVariables(filters) {
+function filtersToQueryAndVariables(filters, solrNamespace = SolrNamespaces.Search) {
+  assert.ok(Object.values(SolrNamespaces).includes(solrNamespace), `Unknown Solr namespace: ${solrNamespace}`);
+
   const filtersGroupedByType = groupBy(filters, 'type');
 
   /** @type {Object.<string, string>} */
@@ -82,9 +88,9 @@ function filtersToQueryAndVariables(filters) {
 
   Object.keys(filtersGroupedByType).forEach((key) => {
     if (NON_FILTERED_FIELDS.indexOf(key) !== -1) {
-      queries.push(filtersToSolr(key, filtersGroupedByType[key]));
+      queries.push(filtersToSolr(key, filtersGroupedByType[key], solrNamespace));
     } else {
-      queries.push(`filter(${filtersToSolr(key, filtersGroupedByType[key])})`);
+      queries.push(`filter(${filtersToSolr(key, filtersGroupedByType[key], solrNamespace)})`);
     }
     if (SOLR_FILTER_DPF[key]) {
       // add payload variable. E.g.: payload(topics_dpf,tmGDL_tp04_fr)

--- a/src/util/solr/index.js
+++ b/src/util/solr/index.js
@@ -58,7 +58,7 @@ function sameTypeFiltersToQuery(filters, solrNamespace = SolrNamespaces.Search) 
   assert.equal(filtersTypes.length, 1, `Filters must be of the same type but they are of: ${filtersTypes.join(', ')}`);
 
   const type = filtersTypes[0];
-  const statement = filtersToSolr(type, filters, solrNamespace);
+  const statement = filtersToSolr(filters, solrNamespace);
 
   return includes(NON_FILTERED_FIELDS, type)
     ? statement
@@ -88,9 +88,9 @@ function filtersToQueryAndVariables(filters, solrNamespace = SolrNamespaces.Sear
 
   Object.keys(filtersGroupedByType).forEach((key) => {
     if (NON_FILTERED_FIELDS.indexOf(key) !== -1) {
-      queries.push(filtersToSolr(key, filtersGroupedByType[key], solrNamespace));
+      queries.push(filtersToSolr(filtersGroupedByType[key], solrNamespace));
     } else {
-      queries.push(`filter(${filtersToSolr(key, filtersGroupedByType[key], solrNamespace)})`);
+      queries.push(`filter(${filtersToSolr(filtersGroupedByType[key], solrNamespace)})`);
     }
     if (SOLR_FILTER_DPF[key]) {
       // add payload variable. E.g.: payload(topics_dpf,tmGDL_tp04_fr)

--- a/src/util/solr/index.js
+++ b/src/util/solr/index.js
@@ -47,8 +47,10 @@ const reduceFiltersToVars = filters => filters.reduce((sq, filter) => {
 
 /**
  * Return a section of the Solr query based on the filters **of the same type**.
- * @param {array} filters a list of filters (`src/schema/search/filter.json`).
+ * @param {import('../../models').Filter[]} filters a list of
+ *        filters (`src/schema/search/filter.json`).
  * @param {string} solrNamespace index to use (see `src/solr.js` - `SolrNamespaces`)
+ *
  * @return {string} a Solr query.
  */
 function sameTypeFiltersToQuery(filters, solrNamespace = SolrNamespaces.Search) {

--- a/src/util/solr/solrFilters.yml
+++ b/src/util/solr/solrFilters.yml
@@ -1,8 +1,13 @@
 indexes:
+  # Index id
   search:
     filters:
+      # filter type
       hasTextContents:
+        # corresponding Solr field
         field: content_length_i
+        # rule to parse filter value (q)
+        # rules handlers are in `filterReducers.js`
         rule: minLengthOne
       ocrQuality:
         field: ocrqa_f
@@ -14,6 +19,7 @@ indexes:
         field: front_b
         rule: boolean
       string:
+        # field prefix, will be expanded to supported languages
         field: { prefix: content_txt_ }
         rule: string
       title:
@@ -59,6 +65,7 @@ indexes:
         field: meta_country_code_s
         rule: value
       mention:
+        # multiple fields per one filter
         field: [pers_mentions, loc_mentions]
         rule: value
       entity:

--- a/src/util/solr/solrFilters.yml
+++ b/src/util/solr/solrFilters.yml
@@ -1,5 +1,5 @@
 indexes:
-  # Index id
+  # Index id (solr namespace)
   search:
     filters:
       # filter type
@@ -97,6 +97,18 @@ indexes:
       textReuseClusterSize:
         field: cluster_size_l
         rule: numericRange
+      daterange:
+        field: min_date_dt
+        rule: dateRange
+      newspaper:
+        field: newspapers_ss
+        rule: value
+      textReuseClusterLexicalOverlap:
+        field: lex_overlap_d
+        rule: numericRange
+      textReuseClusterDayDelta:
+        field: day_delta_i
+        rule: numericRange
   tr_passages:
     filters:
       textReuseClusterSize:
@@ -108,6 +120,12 @@ indexes:
       textReuseClusterDayDelta:
         field: cluster_day_delta_i
         rule: numericRange
+      daterange:
+        field: meta_date_dt
+        rule: dateRange
+      newspaper:
+        field: meta_journal_s
+        rule: value
 
 
 

--- a/src/util/solr/solrFilters.yml
+++ b/src/util/solr/solrFilters.yml
@@ -1,0 +1,116 @@
+indexes:
+  search:
+    filters:
+      hasTextContents:
+        field: content_length_i
+        rule: minLengthOne
+      ocrQuality:
+        field: ocrqa_f
+        rule: numericRange
+      contentLength:
+        field: content_length_i
+        rule: numericRange
+      isFront:
+        field: front_b
+        rule: boolean
+      string:
+        field: { prefix: content_txt_ }
+        rule: string
+      title:
+        field: { prefix: title_txt_ }
+        rule: string
+      daterange:
+        field: meta_date_dt
+        rule: dateRange
+      uid:
+        field: id
+        rule: value
+      accessRight:
+        field: access_right_s
+        rule: value
+      partner:
+        field: meta_partnerid_s
+        rule: value
+      language:
+        field: lg_s
+        rule: value
+      page:
+        field: page_id_ss
+        rule: value
+      collection:
+        field: ucoll_ss
+        rule: value
+      issue:
+        field: meta_issue_id_s
+        rule: value
+      newspaper:
+        field: meta_journal_s
+        rule: value
+      topic:
+        field: topics_dpfs
+        rule: value
+      year:
+        field: meta_year_i
+        rule: value
+      type:
+        field: item_type_s
+        rule: value
+      country:
+        field: meta_country_code_s
+        rule: value
+      mention:
+        field: [pers_mentions, loc_mentions]
+        rule: value
+      entity:
+        field: [pers_entities_dpfs, loc_entities_dpfs]
+        rule: value
+      person:
+        field: pers_entities_dpfs
+        rule: value
+      location:
+        field: loc_entities_dpfs
+        rule: value
+      topicmodel:
+        field: tp_model_s
+        rule: value
+      topic-string:
+        field: topic_suggest
+        rule: string
+      entity-string:
+        field: entitySuggest
+        rule: string
+      entity-type:
+        field: t_s
+        rule: value
+      regex:
+        field: { prefix: content_txt_ }
+        rule: regex
+  tr_clusters:
+    filters:
+      textReuseClusterSize:
+        field: cluster_size_l
+        rule: numericRange
+  tr_passages:
+    filters:
+      textReuseClusterSize:
+        field: cluster_size_l
+        rule: numericRange
+      textReuseClusterLexicalOverlap:
+        field: cluster_lex_overlap_d
+        rule: numericRange
+      textReuseClusterDayDelta:
+        field: cluster_day_delta_i
+        rule: numericRange
+
+
+
+
+
+
+
+
+
+
+
+
+      

--- a/test/hooks/search.test.js
+++ b/test/hooks/search.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 const assert = require('assert');
 const {
   filtersToSolr,
@@ -12,7 +13,7 @@ NODE_ENV=development mocha test/hooks/search.test.js
 */
 describe('test single reducers in search hook', () => {
   it('for language filters', () => {
-    const sq = filtersToSolr('language', [
+    const sq = filtersToSolr([
       {
         context: 'include',
         type: 'language',
@@ -23,7 +24,7 @@ describe('test single reducers in search hook', () => {
   });
 
   it('exclude language filters', () => {
-    const sq = filtersToSolr('language', [
+    const sq = filtersToSolr([
       {
         context: 'exclude',
         type: 'language',
@@ -34,7 +35,7 @@ describe('test single reducers in search hook', () => {
   });
 
   it('test regex filter, multiple words', () => {
-    const sq = filtersToSolr('regex', [{
+    const sq = filtersToSolr([{
       context: 'include',
       type: 'regex',
       q: '/go[uû]t.*parfait.*/',

--- a/test/hooks/search.test.js
+++ b/test/hooks/search.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 const {
-  reduceFiltersToSolr,
-  reduceRegexFiltersToSolr,
+  filtersToSolr,
 } = require('../../src/util/solr/filterReducers');
 const { filtersToSolrQuery, queries } = require('../../src/hooks/search');
+const { SolrNamespaces } = require('../../src/solr');
 
 /*
 ./node_modules/.bin/eslint \
@@ -12,34 +12,34 @@ NODE_ENV=development mocha test/hooks/search.test.js
 */
 describe('test single reducers in search hook', () => {
   it('for language filters', () => {
-    const sq = reduceFiltersToSolr([
+    const sq = filtersToSolr('language', [
       {
         context: 'include',
         type: 'language',
         q: ['fr', 'en'],
       },
-    ], 'lg_s');
+    ], SolrNamespaces.Search);
     assert.deepEqual('(lg_s:fr OR lg_s:en)', sq);
   });
 
   it('exclude language filters', () => {
-    const sq = reduceFiltersToSolr([
+    const sq = filtersToSolr('language', [
       {
         context: 'exclude',
         type: 'language',
         q: ['fr', 'en'],
       },
-    ], 'lg_s');
+    ], SolrNamespaces.Search);
     assert.deepEqual('*:* AND NOT ((lg_s:fr OR lg_s:en))', sq);
   });
 
   it('test regex filter, multiple words', () => {
-    const sq = reduceRegexFiltersToSolr([{
+    const sq = filtersToSolr('regex', [{
       context: 'include',
       type: 'regex',
       q: '/go[uû]t.*parfait.*/',
-    }]);
-    assert.deepEqual('content_txt_fr:/go[uû]t/ AND content_txt_fr:/parfait/', sq);
+    }], SolrNamespaces.Search);
+    assert.deepEqual(sq, '(content_txt_en:/go[uû]t/ OR content_txt_fr:/go[uû]t/ OR content_txt_de:/go[uû]t/) AND (content_txt_en:/parfait/ OR content_txt_fr:/parfait/ OR content_txt_de:/parfait/)');
   });
 });
 

--- a/test/util/solr/reducers.test.js
+++ b/test/util/solr/reducers.test.js
@@ -1,3 +1,4 @@
+// @ts-check
 const assert = require('assert');
 const { SolrNamespaces } = require('../../../src/solr');
 const { filtersToSolr } = require('../../../src/util/solr/filterReducers');
@@ -6,9 +7,10 @@ describe('filtersToSolr', () => {
   it('throws an error for an unknown filter type', () => {
     const filter = {
       type: 'booomooo',
+      q: '',
     };
     assert.throws(
-      () => filtersToSolr(filter.type, [filter], SolrNamespaces.Search),
+      () => filtersToSolr([filter], SolrNamespaces.Search),
       new Error(`Unknown filter type "${filter.type}" in namespace "${SolrNamespaces.Search}"`),
     );
   });
@@ -17,7 +19,7 @@ describe('filtersToSolr', () => {
     const filter = {
       type: 'hasTextContents',
     };
-    const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+    const query = filtersToSolr([filter], SolrNamespaces.Search);
     assert.equal(query, 'content_length_i:[1 TO *]');
   });
 
@@ -27,7 +29,7 @@ describe('filtersToSolr', () => {
         q: '1 TO 10',
         type: 'ocrQuality',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, 'ocrqa_f:[1 TO 10]');
     });
 
@@ -36,7 +38,7 @@ describe('filtersToSolr', () => {
         q: ['2', '20'],
         type: 'ocrQuality',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, 'ocrqa_f:[2 TO 20]');
     });
 
@@ -46,7 +48,7 @@ describe('filtersToSolr', () => {
         type: 'ocrQuality',
       };
       assert.throws(
-        () => filtersToSolr(filter.type, [filter], SolrNamespaces.Search),
+        () => filtersToSolr([filter], SolrNamespaces.Search),
         new Error(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`),
       );
     });
@@ -56,7 +58,7 @@ describe('filtersToSolr', () => {
     const filter = {
       type: 'isFront',
     };
-    const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+    const query = filtersToSolr([filter], SolrNamespaces.Search);
     assert.equal(query, 'front_b:1');
   });
 
@@ -66,7 +68,7 @@ describe('filtersToSolr', () => {
         q: 'moo',
         type: 'title',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(title_txt_en:moo OR title_txt_fr:moo OR title_txt_de:moo)');
     });
 
@@ -75,37 +77,40 @@ describe('filtersToSolr', () => {
         q: ['foo'],
         type: 'title',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(title_txt_en:foo OR title_txt_fr:foo OR title_txt_de:foo)');
     });
 
     it('with text context exact by quotes', () => {
+      /** @type {import('../../../src/models').Filter} */
       const filter = {
         type: 'string',
         context: 'include',
         q: '"ministre portugais"',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")');
     });
 
     it('with text context escaped wrong quotes', () => {
+      /** @type {import('../../../src/models').Filter} */
       const filter = {
         type: 'string',
         context: 'include',
         q: '"ministre "portugais"',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(content_txt_en:"ministre \\"portugais" OR content_txt_fr:"ministre \\"portugais" OR content_txt_de:"ministre \\"portugais")');
     });
 
     it('with text context with multiple content', () => {
+      /** @type {import('../../../src/models').Filter} */
       const filter = {
         type: 'string',
         context: 'include',
         q: ['"ministre portugais"', '"ministre italien"'],
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '((content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais") OR (content_txt_en:"ministre italien" OR content_txt_fr:"ministre italien" OR content_txt_de:"ministre italien"))');
     });
   });
@@ -116,7 +121,7 @@ describe('filtersToSolr', () => {
         q: '1918 TO 2018',
         type: 'daterange',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, 'meta_date_dt:[1918 TO 2018]');
     });
 
@@ -125,7 +130,7 @@ describe('filtersToSolr', () => {
         q: ['1918', '2018'],
         type: 'daterange',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(meta_date_dt:[1918] OR meta_date_dt:[2018])');
     });
 
@@ -135,7 +140,7 @@ describe('filtersToSolr', () => {
         type: 'daterange',
       };
       assert.throws(
-        () => filtersToSolr(filter.type, [filter], SolrNamespaces.Search),
+        () => filtersToSolr([filter], SolrNamespaces.Search),
         new Error(`"dateRange" filter rule: unknown value encountered in "q": ${filter.q}`),
       );
     });
@@ -147,7 +152,7 @@ describe('filtersToSolr', () => {
         q: 'en',
         type: 'language',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, 'lg_s:en');
     });
 
@@ -156,7 +161,7 @@ describe('filtersToSolr', () => {
         q: ['en', 'fr'],
         type: 'language',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(lg_s:en OR lg_s:fr)');
     });
 
@@ -165,7 +170,7 @@ describe('filtersToSolr', () => {
         q: ['ab', 'cd'],
         type: 'mention',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(pers_mentions:ab OR loc_mentions:ab OR pers_mentions:cd OR loc_mentions:cd)');
     });
   });
@@ -176,7 +181,7 @@ describe('filtersToSolr', () => {
         q: 'moo',
         type: 'regex',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(content_txt_en:/moo/ OR content_txt_fr:/moo/ OR content_txt_de:/moo/)');
     });
 
@@ -185,7 +190,7 @@ describe('filtersToSolr', () => {
         q: ['foo'],
         type: 'regex',
       };
-      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      const query = filtersToSolr([filter], SolrNamespaces.Search);
       assert.equal(query, '(content_txt_en:/foo/ OR content_txt_fr:/foo/ OR content_txt_de:/foo/)');
     });
   });

--- a/test/util/solr/reducers.test.js
+++ b/test/util/solr/reducers.test.js
@@ -33,11 +33,22 @@ describe('filtersToSolr', () => {
 
     it('with array', () => {
       const filter = {
-        q: [2, 20],
+        q: ['2', '20'],
         type: 'ocrQuality',
       };
       const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
       assert.equal(query, 'ocrqa_f:[2 TO 20]');
+    });
+
+    it('throws an error with malformed string', () => {
+      const filter = {
+        q: 'foo bar',
+        type: 'ocrQuality',
+      };
+      assert.throws(
+        () => filtersToSolr(filter.type, [filter], SolrNamespaces.Search),
+        new Error(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`),
+      );
     });
   });
 
@@ -57,6 +68,15 @@ describe('filtersToSolr', () => {
       };
       const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
       assert.equal(query, '(title_txt_en:moo OR title_txt_fr:moo OR title_txt_de:moo)');
+    });
+
+    it('with array', () => {
+      const filter = {
+        q: ['foo'],
+        type: 'title',
+      };
+      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      assert.equal(query, '(title_txt_en:foo OR title_txt_fr:foo OR title_txt_de:foo)');
     });
   });
 });

--- a/test/util/solr/reducers.test.js
+++ b/test/util/solr/reducers.test.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const { SolrNamespaces } = require('../../../src/solr');
+const { filtersToSolr } = require('../../../src/util/solr/filterReducers');
+
+describe('filtersToSolr', () => {
+  it('throws an error for an unknown filter type', () => {
+    const filter = {
+      type: 'booomooo',
+    };
+    assert.throws(
+      () => filtersToSolr(filter.type, [filter], SolrNamespaces.Search),
+      new Error(`Unknown filter type "${filter.type}" in namespace "${SolrNamespaces.Search}"`),
+    );
+  });
+
+  it('handles "minLengthOne" filter', () => {
+    const filter = {
+      type: 'hasTextContents',
+    };
+    const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+    assert.equal(query, 'content_length_i:[1 TO *]');
+  });
+
+  describe('handles "numericRange" filter', () => {
+    it('with string', () => {
+      const filter = {
+        q: '1 TO 10',
+        type: 'ocrQuality',
+      };
+      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      assert.equal(query, 'ocrqa_f:[1 TO 10]');
+    });
+
+    it('with array', () => {
+      const filter = {
+        q: [2, 20],
+        type: 'ocrQuality',
+      };
+      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      assert.equal(query, 'ocrqa_f:[2 TO 20]');
+    });
+  });
+
+  it('handles "boolean" filter', () => {
+    const filter = {
+      type: 'isFront',
+    };
+    const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+    assert.equal(query, 'front_b:1');
+  });
+
+  describe('handles "string" filter', () => {
+    it('with string', () => {
+      const filter = {
+        q: 'moo',
+        type: 'title',
+      };
+      const query = filtersToSolr(filter.type, [filter], SolrNamespaces.Search);
+      assert.equal(query, '(title_txt_en:moo OR title_txt_fr:moo OR title_txt_de:moo)');
+    });
+  });
+});


### PR DESCRIPTION
Now that we have more than one index with different sets of fields mapping to different filters that do not necessarily overlap I refactored the filter -> solr query conversion code to take the index into account. It also moved the mapping code into a `yaml` file to make it easier to read and maintain.