### PR TITLE
Added missing content field

### DIFF
--- a/src/services/articles/articles.class.js
+++ b/src/services/articles/articles.class.js
@@ -140,6 +140,12 @@ class Service {
       'rb_plain:[json]',
       'pp_plain:[json]',
       'nem_offset_plain:[json]',
+      // [RK] Note: The content fields below are missing in
+      // `ARTICLE_SOLR_FL_LIST_ITEM`. Not clear what the reason is
+      // but they are certainly needed.
+      'content_txt_fr',
+      'content_txt_en',
+      'content_txt_de',
     ]) : Article.ARTICLE_SOLR_FL;
 
     return Promise.all([


### PR DESCRIPTION
Article content fields have not been added to the list of fields in version `1.2.0`. Back then it was probably fine because the content was retrieved from Solr in another place (not sure where). In current version of Impresso rendering of article content has been moved from backend to frontend. The content string is required on the frontend to render article content. This fix adds content to the article.

This problem did not advertise itself in preprod because the set of fields depends on data version and they are different in preprod and production.