### PR TITLE
added sort parameter

### DIFF
--- a/src/services/stats/stats.class.js
+++ b/src/services/stats/stats.class.js
@@ -95,7 +95,7 @@ const getDomainDetails = (index, domain, filters) => {
   return statsConfiguration.indexes[index].facets.term[domain];
 };
 
-function buildSolrRequest (facet, index, domain, stats, filters) {
+function buildSolrRequest (facet, index, domain, stats, filters, sort) {
   const facetType = getFacetType(index, facet);
   const domainDetails = getDomainDetails(index, domain, filters);
 
@@ -110,6 +110,7 @@ function buildSolrRequest (facet, index, domain, stats, filters) {
         type: 'terms',
         field: domainDetails.field,
         limit: domainDetails.limit,
+        sort: sort,
         facet: getFacetQueryPart(facet, index, facetType, stats),
       },
     },
@@ -205,10 +206,10 @@ class Stats {
 
   async find ({
     request: {
-      facet, index, domain, stats, filters,
+      facet, index, domain, stats, filters, sort
     },
   }) {
-    const request = buildSolrRequest(facet, index, domain, stats, filters);
+    const request = buildSolrRequest(facet, index, domain, stats, filters, sort);
     const result = await this.solr.post(request, index);
     return buildResponse(result, facet, index, domain, filters);
   }

--- a/src/services/stats/stats.hooks.js
+++ b/src/services/stats/stats.hooks.js
@@ -34,6 +34,7 @@ function parseAndValidateQueryParameters (context) {
     domain = 'time',
     stats: statsString,
     filters: serializedFilters,
+    sort
   } = context.params.query;
 
   assert.ok(SupportedIndexes.includes(index), new BadRequest(`Unknown index "${index}". Must be one of: ${SupportedIndexes.join(', ')}`));
@@ -56,6 +57,7 @@ function parseAndValidateQueryParameters (context) {
     domain,
     stats,
     filters,
+    sort
   };
 }
 


### PR DESCRIPTION
Enables sorting by facets.

Default sorting (count):

```
curl --location --request GET 'http://localhost:3030/stats?facet=textReuseClusterSize&index=tr_passages&domain=newspaper'
```

Sorting by a facet (stddev asc):

```
curl --location --request GET 'http://localhost:3030/stats?facet=textReuseClusterSize&index=tr_passages&domain=newspaper&sort=stddev%20asc'
```