### PR TITLE
[chore] filters query parameter refactoring

### DIFF
--- a/src/services/articles/articles.schema.ts
+++ b/src/services/articles/articles.schema.ts
@@ -1,5 +1,4 @@
 import { ServiceSwaggerOptions } from 'feathers-swagger'
-import { REGEX_UID } from '../../hooks/params'
 import type { MethodParameter } from '../../util/openapi'
 import { getStandardParameters, getStandardResponses } from '../../util/openapi'
 
@@ -23,30 +22,6 @@ const findParameters: MethodParameter[] = [
       enum: ['-date', 'date', '-relevance', 'relevance'],
     },
     description: 'Order by term',
-  },
-  {
-    in: 'query',
-    name: 'filters',
-    required: false,
-    schema: {
-      type: 'array',
-      items: {
-        type: 'object',
-        additionalProperties: false,
-        required: ['type'],
-        properties: {
-          type: {
-            type: 'string',
-            enum: ['uid', 'issue', 'page', 'newspaper', 'hasTextContents'],
-          },
-          q: {
-            type: 'string',
-            pattern: String(REGEX_UID).slice(1, -1),
-          },
-        },
-      },
-    },
-    description: 'Filters to apply',
   },
   ...getStandardParameters({ method: 'find' }),
 ]

--- a/src/services/newspapers/newspapers.class.js
+++ b/src/services/newspapers/newspapers.class.js
@@ -1,20 +1,17 @@
-const debug = require('debug')('impresso/services:newspapers');
-const { Op } = require('sequelize');
-const SequelizeService = require('../sequelize.service');
-const { measureTime } = require('../../util/instruments');
+const debug = require('debug')('impresso/services:newspapers')
+const { Op } = require('sequelize')
+const SequelizeService = require('../sequelize.service')
+const { measureTime } = require('../../util/instruments')
 
 class Service {
-  constructor ({
-    app,
-    name = '',
-  } = {}) {
-    this.app = app;
-    this.name = name;
+  constructor({ app, name = '' } = {}) {
+    this.app = app
+    this.name = name
     this.SequelizeService = SequelizeService({
       app,
       name,
       cacheReads: true,
-    });
+    })
   }
 
   /**
@@ -22,53 +19,53 @@ class Service {
    * @param  {String}  id     uid or acronym of the newspaper
    * @return {Promise}        [description]
    */
-  async get (id) {
+  async get(id) {
     const where = {
       uid: id,
-    };
-    return measureTime(() => this.SequelizeService.get(id, {
-      scope: 'get',
-      where,
-    }).then(d => d.toJSON()), 'newspapers.get.db.newspaper');
+    }
+    return measureTime(
+      () =>
+        this.SequelizeService.get(id, {
+          scope: 'get',
+          where,
+        }).then(d => d.toJSON()),
+      'newspapers.get.db.newspaper'
+    )
   }
 
-  async find (params) {
-    debug(`find '${this.name}': with params.isSafe:${params.isSafe} and params.query:`, params.query);
+  async find(params) {
+    debug(`find '${this.name}': with params.isSafe:${params.isSafe} and params.query:`, params.query)
 
-    const where = {};
+    const where = {}
 
     if (params.query.q) {
-      where[Op.or] = [
-        { name: params.query.q },
-        { uid: params.query.q },
-      ];
+      where[Op.or] = [{ name: params.query.q }, { uid: params.query.q }]
     }
 
-    const scope = params.query.faster ? 'lookup' : 'find';
+    const scope = params.query.faster ? 'lookup' : 'find'
 
-    if (params.query.filters && params.query.filters.length) {
-      where[Op.and] = [];
-      if (params.query.filters.some(d => d.type === 'included')) {
-        where[Op.and].push({
+    if (params.query.includedOnly) {
+      where[Op.and] = [
+        {
           '$stats.start$': { [Op.not]: null },
-        });
-      } else if (params.query.filters.some(d => d.type === 'excluded')) {
-        where[Op.and].push({
-          '$stats.start$': { [Op.is]: null },
-        });
-      }
+        },
+      ]
     }
 
-    return measureTime(() => this.SequelizeService.find({
-      ...params,
-      where,
-      scope,
-      distinct: true,
-    }), 'newspapers.find.db.newspapers');
+    return measureTime(
+      () =>
+        this.SequelizeService.find({
+          ...params,
+          where,
+          scope,
+          distinct: true,
+        }),
+      'newspapers.find.db.newspapers'
+    )
   }
 }
 
 module.exports = function (options) {
-  return new Service(options);
-};
-module.exports.Service = Service;
+  return new Service(options)
+}
+module.exports.Service = Service

--- a/src/services/newspapers/newspapers.hooks.js
+++ b/src/services/newspapers/newspapers.hooks.js
@@ -2,7 +2,7 @@ import { authenticateAround as authenticate } from '../../hooks/authenticate'
 import { rateLimit } from '../../hooks/rateLimiter'
 import { OrderByChoices } from './newspapers.schema'
 
-const { queryWithCommonParams, validate, validateEach, utils } = require('../../hooks/params')
+const { queryWithCommonParams, validate, utils } = require('../../hooks/params')
 const { checkCachedContents, returnCachedContents, saveResultsInCache } = require('../../hooks/redis')
 
 module.exports = {
@@ -17,6 +17,10 @@ module.exports = {
     ],
     find: [
       validate({
+        includedOnly: {
+          required: false,
+          transform: d => !!d,
+        },
         q: {
           required: false,
           max_length: 500,
@@ -51,18 +55,6 @@ module.exports = {
             }),
         },
       }),
-      validateEach(
-        'filters',
-        {
-          type: {
-            choices: ['included', 'excluded'],
-            required: true,
-          },
-        },
-        {
-          required: false,
-        }
-      ),
       queryWithCommonParams(),
     ],
     get: [],

--- a/src/services/newspapers/newspapers.schema.ts
+++ b/src/services/newspapers/newspapers.schema.ts
@@ -21,13 +21,12 @@ export const OrderByChoices = [
 const findParameters: QueryParameter[] = [
   {
     in: 'query',
-    name: 'filters',
+    name: 'includedOnly',
     required: false,
     schema: {
-      type: 'array',
-      items: getSchemaRef('Filter'),
+      type: 'boolean',
     },
-    description: 'Filters to apply',
+    description: 'Return included newspapers only (TODO)',
   },
   {
     in: 'query',

--- a/src/services/search-facets/search-facets.schema.ts
+++ b/src/services/search-facets/search-facets.schema.ts
@@ -1,6 +1,6 @@
 import type { ServiceSwaggerOptions } from 'feathers-swagger'
 import { SolrMappings } from '../../data/constants'
-import { QueryParameter, getSchemaRef, getStandardParameters, getStandardResponses } from '../../util/openapi'
+import { QueryParameter, filtersQueryParameter, getStandardParameters, getStandardResponses } from '../../util/openapi'
 
 const SupportedIndexes = Object.keys(SolrMappings)
 
@@ -41,16 +41,7 @@ const getGetParameters = (index: IndexId): QueryParameter[] => [
     },
     description: 'Group by',
   },
-  {
-    in: 'query',
-    name: 'filters',
-    required: false,
-    schema: {
-      type: 'array',
-      items: getSchemaRef('Filter'),
-    },
-    description: 'Filters to apply',
-  },
+  filtersQueryParameter,
   {
     in: 'query',
     name: 'range_start',

--- a/src/services/search/search.schema.ts
+++ b/src/services/search/search.schema.ts
@@ -1,7 +1,7 @@
 import { ServiceSwaggerOptions, operation } from 'feathers-swagger'
 import { SolrMappings } from '../../data/constants'
 import type { MethodParameter } from '../../util/openapi'
-import { getSchemaRef, getStandardParameters, getStandardResponses } from '../../util/openapi'
+import { filtersQueryParameter, getSchemaRef, getStandardParameters, getStandardResponses } from '../../util/openapi'
 import { paramsValidator } from './search.validators'
 
 const findParameters: MethodParameter[] = [
@@ -47,16 +47,7 @@ const findParameters: MethodParameter[] = [
     },
     description: 'Facet to return',
   },
-  {
-    in: 'query',
-    name: 'filters',
-    required: false,
-    schema: {
-      type: 'array',
-      items: getSchemaRef('Filter'),
-    },
-    description: 'Filters to apply',
-  },
+  filtersQueryParameter,
   ...getStandardParameters({ method: 'find' }),
 ]
 

--- a/src/services/text-reuse-clusters/text-reuse-clusters.schema.ts
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.schema.ts
@@ -1,6 +1,6 @@
 import type { ServiceSwaggerOptions } from 'feathers-swagger'
 import type { MethodParameter } from '../../util/openapi'
-import { getSchemaRef, getStandardParameters, getStandardResponses } from '../../util/openapi'
+import { filtersQueryParameter, getStandardParameters, getStandardResponses } from '../../util/openapi'
 import { OrderByKeyToField } from './text-reuse-clusters.class'
 import { Filter } from '../../models'
 
@@ -34,16 +34,7 @@ const findParameters: MethodParameter[] = [
     },
     description: 'Order by term',
   },
-  {
-    in: 'query',
-    name: 'filters',
-    required: false,
-    schema: {
-      type: 'array',
-      items: getSchemaRef('Filter'),
-    },
-    description: 'Filters to apply',
-  },
+  filtersQueryParameter,
   ...getStandardParameters({ method: 'find', maxPageSize: 20 }),
 ]
 

--- a/src/services/text-reuse-passages/text-reuse-passages.schema.ts
+++ b/src/services/text-reuse-passages/text-reuse-passages.schema.ts
@@ -1,6 +1,6 @@
 import type { ServiceSwaggerOptions } from 'feathers-swagger'
 import type { MethodParameter } from '../../util/openapi'
-import { getParameterRef, getSchemaRef, getStandardParameters, getStandardResponses } from '../../util/openapi'
+import { filtersQueryParameter, getStandardParameters, getStandardResponses } from '../../util/openapi'
 import { GroupByValues, OrderByKeyToField } from './text-reuse-passages.class'
 
 const findParameters: MethodParameter[] = [
@@ -26,16 +26,7 @@ const findParameters: MethodParameter[] = [
     },
     description: 'Group by term',
   },
-  {
-    in: 'query',
-    name: 'filters',
-    required: false,
-    schema: {
-      type: 'array',
-      items: getSchemaRef('Filter'),
-    },
-    description: 'Filters to apply',
-  },
+  filtersQueryParameter,
   {
     in: 'query',
     name: 'addons',

--- a/src/util/openapi.ts
+++ b/src/util/openapi.ts
@@ -227,3 +227,11 @@ export const getResponseContent = (schemaName: string) => {
 export const getDefaultErrorResponseContent = () => {
   return asApplicationProblemJson(defaultErrorSchema)
 }
+
+export const filtersQueryParameter: QueryParameter = {
+  in: 'query',
+  name: 'filters',
+  required: false,
+  schema: { oneOf: [{ type: 'string' }, { type: 'array', items: getSchemaRef('Filter') }] },
+  description: 'Create filters using Impresso <a href="https://example.com" target="_blank">filter builder</a>.',
+}


### PR DESCRIPTION
* Removed filters query parameter where it does not make sense. Reuse OpenAPI filters parameter descriptor in all other places.
* Replaced `filters` with `isIncluded` flag in the `newspaper find` endpoint.