### PR TITLE
[chore] Do not double-validate filters and construct the Solr query correctly

### DIFF
--- a/src/services/text-reuse-clusters/text-reuse-clusters.class.ts
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.class.ts
@@ -42,9 +42,9 @@ function buildResponseClusters(clusters: any, clusterIdsAndText: { id: any; text
 
 const deserializeFilters = (serializedFilters: string) => protobuf.searchQuery.deserialize(serializedFilters).filters
 
-function filtersToSolrQueries(filters: any) {
+function filtersToSolrQueries(filters: any, namespace = SolrNamespaces.TextReusePassages) {
   const filtersGroupsByType = values(groupBy(filters, 'type'))
-  return uniq(filtersGroupsByType.map((f: any) => sameTypeFiltersToQuery(f, SolrNamespaces.TextReusePassages)))
+  return uniq(filtersGroupsByType.map((f: any) => sameTypeFiltersToQuery(f, namespace)))
 }
 
 export const OrderByKeyToField = {
@@ -122,7 +122,7 @@ export class TextReuseClusters {
   async find(params: Params<FindQueyParameters>): Promise<FindTextReuseClustersResponse> {
     const { text, offset = 0, limit = 10, order_by: orderBy } = params.query ?? {}
     const { filters }: Pick<FindQueyParameters, 'filters'> = (params as any).sanitized ?? {}
-    const filterQueryParts = filtersToSolrQueries(filters)
+    const filterQueryParts = filtersToSolrQueries(filters, SolrNamespaces.TextReuseClusters)
     const [orderByField, orderByDescending] = parseOrderBy(orderBy, OrderByKeyToField)
     const query = getTextReusePassagesClusterIdsSearchRequestForText(
       text,

--- a/src/services/text-reuse-clusters/text-reuse-clusters.class.ts
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.class.ts
@@ -53,7 +53,7 @@ export const OrderByKeyToField = {
 
 const withExtraQueryParts = (query: { q: any }, parts: any) => {
   const updatedQuery = clone(query)
-  updatedQuery.q = [query.q].concat(parts).join(' AND ')
+  updatedQuery.q = [`(${query.q})`].concat(parts).join(' AND ')
   return updatedQuery
 }
 
@@ -122,7 +122,7 @@ export class TextReuseClusters {
   async find(params: Params<FindQueyParameters>): Promise<FindTextReuseClustersResponse> {
     const { text, offset = 0, limit = 10, order_by: orderBy } = params.query ?? {}
     const { filters }: Pick<FindQueyParameters, 'filters'> = (params as any).sanitized ?? {}
-    const filterQueryParts = filtersToSolrQueries(filters, SolrNamespaces.TextReuseClusters)
+    const filterQueryParts = filtersToSolrQueries(filters, SolrNamespaces.TextReusePassages)
     const [orderByField, orderByDescending] = parseOrderBy(orderBy, OrderByKeyToField)
     const query = getTextReusePassagesClusterIdsSearchRequestForText(
       text,

--- a/src/services/text-reuse-clusters/text-reuse-clusters.hooks.js
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.hooks.js
@@ -1,8 +1,6 @@
 import { authenticateAround as authenticate } from '../../hooks/authenticate'
 import { rateLimit } from '../../hooks/rateLimiter'
 import { decodeJsonQueryParameters } from '../../hooks/parameters'
-import { validate } from '../../hooks/params'
-import { parseFilters } from '../../util/queryParameters'
 
 // const { validateWithSchema } = require('../../hooks/schema')
 
@@ -14,12 +12,6 @@ module.exports = {
     all: [],
     find: [
       decodeJsonQueryParameters(['filters']), //
-      validate({
-        filters: {
-          required: false,
-          transform: parseFilters,
-        },
-      }),
     ],
     get: [],
     create: [],

--- a/src/services/text-reuse-clusters/text-reuse-clusters.hooks.js
+++ b/src/services/text-reuse-clusters/text-reuse-clusters.hooks.js
@@ -1,6 +1,8 @@
 import { authenticateAround as authenticate } from '../../hooks/authenticate'
 import { rateLimit } from '../../hooks/rateLimiter'
 import { decodeJsonQueryParameters } from '../../hooks/parameters'
+import { validate } from '../../hooks/params'
+import { parseFilters } from '../../util/queryParameters'
 
 // const { validateWithSchema } = require('../../hooks/schema')
 
@@ -12,6 +14,12 @@ module.exports = {
     all: [],
     find: [
       decodeJsonQueryParameters(['filters']), //
+      validate({
+        filters: {
+          required: false,
+          transform: f => parseFilters(f)[0], // parse a single filter
+        },
+      }),
     ],
     get: [],
     create: [],


### PR DESCRIPTION
This PR contains two fixes:

1. Filters were double parsed resulting in an array of arrays structure. Fixed to have a single top level array.
2. Text reuse passages queries with text and filters were not built correctly:
    - Before: `content_txt_fr:"Plus" OR content_txt_de:"Plus" OR content_txt_en:"Plus" AND filter(cluster_size_l:[50 TO 100])`
    - After: `(content_txt_fr:"Plus" OR content_txt_de:"Plus" OR content_txt_en:"Plus") AND filter(cluster_size_l:[50 TO 100])`