### PR TITLE
[feature] JWT APP auth strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ There are several configuration options that should be set differently in Public
    * `expiresIn` - should be set to a reasonable value for the public API (e.g. `8h` for 8 hours)
  * `authentication.cookie.enabled` set to `false` - cookies are not used in the public API
 
+Additionally, to enable the public API to verify web app IML token, the following configuration block should be added:
+
+```json
+"imlAuthConfiguration": {
+  "secret": "IML jwt secret",
+  "jwtOptions": {
+    "audience": "Web app base URL"
+  }
+}
+```
+
+Where:
+  * `secret` - secret used to sign the IML tokens
+  * `audience` - base URL of the web app issuing the token.
+
+To let the authentication service know that a new auth strategy is installed, add the following to the "authentication" block:
+
+```json
+  "authStrategies": ["local", "jwt-app", "jwt"]
+```
+
 ## Help
 
 For more information on all the things you can do with Feathers visit [docs.feathersjs.com](http://docs.feathersjs.com).

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -150,7 +150,10 @@ export default (app: ImpressoApplication) => {
 
   authentication.register('jwt', jwtStrategy)
   authentication.register('local', new HashedPasswordVerifier())
-  authentication.register('jwt-app', new ImlAppJWTStrategy())
+
+  if (isPublicApi) {
+    authentication.register('jwt-app', new ImlAppJWTStrategy())
+  }
 
   app.use('/authentication', authentication, {
     methods: isPublicApi ? ['create'] : undefined,

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -4,15 +4,16 @@ import {
   AuthenticationResult,
   AuthenticationService,
   JWTStrategy,
+  JwtVerifyOptions,
 } from '@feathersjs/authentication'
 import { LocalStrategy } from '@feathersjs/authentication-local'
 import { NotAuthenticated } from '@feathersjs/errors'
+import { ServiceOptions } from '@feathersjs/feathers'
 import initDebug from 'debug'
 import { createSwaggerServiceOptions } from 'feathers-swagger'
 import User from './models/users.model'
 import { docs } from './services/authentication/authentication.schema'
 import { ImpressoApplication } from './types'
-import { ServiceOptions } from '@feathersjs/feathers'
 
 const debug = initDebug('impresso/authentication')
 
@@ -98,6 +99,48 @@ class NoDBJWTStrategy extends JWTStrategy {
   }
 }
 
+/**
+ * A custom JWT strategy that verifies the IML (web app) JWT
+ * token and issues a public API short-lived token.
+ */
+class ImlAppJWTStrategy extends JWTStrategy {
+  async authenticate(authentication: AuthenticationRequest, params: AuthenticationParams) {
+    const { accessToken } = authentication
+    if (!accessToken) {
+      throw new NotAuthenticated('No access token')
+    }
+
+    const authConfig = (this.app as ImpressoApplication)?.get('imlAuthConfiguration')
+
+    const imlOps: JwtVerifyOptions = { ...params.jwt }
+    if (authConfig != null) {
+      imlOps.audience = authConfig.jwtOptions.audience
+    }
+
+    const payload = await this.authentication?.verifyAccessToken(accessToken, imlOps, authConfig?.secret)
+
+    const { entity } = this.configuration
+
+    return {
+      authentication: { strategy: this.name },
+      [entity]: await this.getEntity(payload.sub, params),
+    } as any
+  }
+
+  get configuration() {
+    const authConfig = this.authentication?.configuration
+    const config = super.configuration
+    return {
+      ...config,
+      service: authConfig?.service,
+      entity: authConfig?.entity,
+      entityId: authConfig?.entityId,
+      header: '',
+      schemes: ['JWT-APP'],
+    }
+  }
+}
+
 export default (app: ImpressoApplication) => {
   const isPublicApi = app.get('isPublicApi')
   const useDbUserInRequestContext = app.get('useDbUserInRequestContext')
@@ -107,6 +150,7 @@ export default (app: ImpressoApplication) => {
 
   authentication.register('jwt', jwtStrategy)
   authentication.register('local', new HashedPasswordVerifier())
+  authentication.register('jwt-app', new ImlAppJWTStrategy())
 
   app.use('/authentication', authentication, {
     methods: isPublicApi ? ['create'] : undefined,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -79,6 +79,7 @@ export interface FeaturesConfiguration {
 export interface LocalAuthenticationConfiguration extends AuthenticationConfiguration {
   jwtOptions: {
     issuer: string
+    audience: string
   }
 }
 
@@ -91,8 +92,15 @@ export interface Configuration {
   useDbUserInRequestContext?: boolean
   problemUriBase?: string
   features?: FeaturesConfiguration
-  // TODO: move to services:
   authentication: LocalAuthenticationConfiguration
+  /**
+   * Configuration for the auth strategy in Public API
+   * where the API can verify a token from the internal API
+   * (IML) using this configuration and then issue a new token
+   * for the public API.
+   */
+  imlAuthConfiguration?: LocalAuthenticationConfiguration
+  // TODO: move to services:
   sequelize: SequelizeConfiguration
   sequelizeClient?: Sequelize
   celery?: CeleryConfiguration

--- a/src/schema/schemas/AuthenticationCreateRequest.json
+++ b/src/schema/schemas/AuthenticationCreateRequest.json
@@ -3,11 +3,12 @@
   "title": "Authentication Create Request",
   "description": "Request body for the authentication endpoint",
   "type": "object",
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
-    "strategy": { "type": "string", "enum": ["local"] },
+    "strategy": { "type": "string", "enum": ["local", "jwt-app"] },
     "email": { "type": "string" },
-    "password": { "type": "string" }
+    "password": { "type": "string" },
+    "accessToken": { "type": "string" }
   },
-  "required": ["strategy", "email", "password"]
+  "required": ["strategy"]
 }


### PR DESCRIPTION
Adds an authentication strategy that verifies a long-lived auth token issued by the web app and returns a new short-lived JWT token for the Public API.