### PR TITLE
[feature] New facet order_by option: "value"

### DIFF
--- a/src/services/search-facets/search-facets.hooks.ts
+++ b/src/services/search-facets/search-facets.hooks.ts
@@ -24,6 +24,12 @@ const getAndFindHooks = (index: IndexId) => [
           count: {
             count: 'asc',
           },
+          '-value': {
+            index: 'desc',
+          },
+          value: {
+            index: 'asc',
+          },
         }),
     },
     group_by: {

--- a/src/services/search-facets/search-facets.schema.ts
+++ b/src/services/search-facets/search-facets.schema.ts
@@ -18,7 +18,7 @@ const facetNames: Record<IndexId, string> = {
   'tr-passages': 'text reuse passages index',
 }
 
-export const OrderByChoices = ['-count', 'count']
+export const OrderByChoices = ['-count', 'count', '-value', 'value']
 
 const getGetParameters = (index: IndexId): QueryParameter[] => [
   {


### PR DESCRIPTION
Adds a new "order by" option to facets: "value". This option should be used by the impresso-py library by default, because that's how the users will likely want to see their facets most of the time, especially the ones that deal with dates.