### PR TITLE
[FIX] Fixed value filter to cover AND + OR case

### DIFF
--- a/src/util/solr/filterBuilders/base.ts
+++ b/src/util/solr/filterBuilders/base.ts
@@ -1,0 +1,119 @@
+import { Filter } from '../../../models'
+import {
+  BaseFilterBuilderFn,
+  FilterField,
+  FilterFieldConverter,
+  isMultiValueFilterField,
+  isPrefixedFilterField,
+  ItemBuilder,
+  ValueTransformer,
+} from './types'
+
+interface FilterStatement<T> {
+  items: T[]
+  op: 'OR' | 'AND'
+  negated?: boolean
+}
+
+const isArrayValue = (filterValue?: string | string[]): filterValue is string[] => Array.isArray(filterValue)
+const isNonEmptyStringValue = (filterValue?: string | string[]): filterValue is string =>
+  typeof filterValue === 'string' && filterValue.trim() !== ''
+
+const toFilterStatements = (value: string, fields: string[], buildItem: ItemBuilder): FilterStatement<string> => {
+  const items = fields.map(field => buildItem(field, value))
+  return {
+    items,
+    op: 'OR',
+  }
+}
+
+const filterAsFilterStatement = (
+  filter: Filter,
+  fields: string[],
+  transformValue: ValueTransformer,
+  buildItem: ItemBuilder
+): FilterStatement<FilterStatement<string>> => {
+  const op = filter.op || 'OR'
+  const negated = filter.context === 'exclude'
+
+  if (isArrayValue(filter.q)) {
+    const values = filter.q.length > 0 ? filter.q : ['*']
+    const items = values.map(value => toFilterStatements(transformValue(value), fields, buildItem))
+
+    return {
+      items,
+      op,
+      negated,
+    }
+  } else if (isNonEmptyStringValue(filter.q)) {
+    const item = toFilterStatements(transformValue(filter.q), fields, buildItem)
+    return {
+      items: [item],
+      op,
+      negated,
+    }
+  } else {
+    const item = toFilterStatements('*', fields, buildItem)
+    return {
+      items: [item],
+      op,
+      negated,
+    }
+  }
+}
+
+const filterStatementToString = (statement: FilterStatement<any> | string): string => {
+  if (typeof statement === 'string') return statement
+
+  const items = statement.items.map(filterStatementToString).filter(item => item.trim() !== '')
+  const usedItems = items.length > 0 ? items : ['*:*']
+  const str = usedItems.join(` ${statement.op} `)
+  const groupedString = items.length > 1 ? `(${str})` : str
+  return statement.negated ? `NOT ${groupedString}` : groupedString
+}
+
+/**
+ * Transform string to string.
+ */
+export const identityTransformValue = <T>(v: T): T => v
+
+/**
+ * Default SOLR builder: field:value
+ */
+export const defaultItemBuilder = (field: string, value: string) => `${field}:${value}`
+
+/**
+ * Converter that prevents the use of prefixes in filter fields
+ */
+export const noPrefixFilterFieldConverter: FilterFieldConverter = filterField => {
+  if (isPrefixedFilterField(filterField)) throw new Error(`Prefixed filter fields are not supported`)
+  return isMultiValueFilterField(filterField) ? filterField : [filterField]
+}
+
+const baseFilterBuilderFn: BaseFilterBuilderFn = (
+  filters: Filter[],
+  filterField: FilterField,
+  ruleName: string,
+  transformValue: ValueTransformer = identityTransformValue,
+  buildItem: ItemBuilder = defaultItemBuilder,
+  filterFieldConverter: FilterFieldConverter = noPrefixFilterFieldConverter
+): string => {
+  try {
+    const fields = filterFieldConverter(filterField)
+    const statements = filters.map(filter => filterAsFilterStatement(filter, fields, transformValue, buildItem))
+
+    const statement: FilterStatement<FilterStatement<FilterStatement<string>>> = {
+      items: statements,
+      op: 'AND',
+    }
+
+    return filterStatementToString(statement)
+  } catch (e) {
+    const error = e as Error
+    const newError = new Error(`Error building filter for rule ${ruleName}: ${error.message}`)
+    newError.stack = error.stack
+    throw newError
+  }
+}
+
+export default baseFilterBuilderFn

--- a/src/util/solr/filterBuilders/capitalisedValue.ts
+++ b/src/util/solr/filterBuilders/capitalisedValue.ts
@@ -1,0 +1,20 @@
+import { Filter } from '../../../models'
+import baseFilterBuilderFn, { defaultItemBuilder, noPrefixFilterFieldConverter } from './base'
+import { FilterBuilderFn, FilterField } from './types'
+import { escapeString } from './value'
+
+const toCapitalised = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1)
+const transformValue = (value: string): string => escapeString(toCapitalised(value))
+
+const valueBuilder: FilterBuilderFn = (filters: Filter[], filterField: FilterField, ruleName: string) => {
+  return baseFilterBuilderFn(
+    filters,
+    filterField,
+    ruleName,
+    transformValue,
+    defaultItemBuilder,
+    noPrefixFilterFieldConverter
+  )
+}
+
+export default valueBuilder

--- a/src/util/solr/filterBuilders/types.ts
+++ b/src/util/solr/filterBuilders/types.ts
@@ -1,0 +1,38 @@
+import { Filter } from '../../../models'
+
+export interface PrefixedFilterField {
+  prefix: string
+}
+
+export type FilterField = string | string[] | PrefixedFilterField
+
+export const isPrefixedFilterField = (field: FilterField): field is PrefixedFilterField => {
+  return (field as PrefixedFilterField).prefix !== undefined
+}
+
+export const isMultiValueFilterField = (field: FilterField): field is string[] => {
+  return Array.isArray(field)
+}
+
+/**
+ * A filter descriptor entry in solrFilters.yml
+ */
+export interface FilterDescriptor {
+  field: FilterField
+  rule: string
+}
+
+export type ValueTransformer = (value: string) => string
+export type ItemBuilder = (field: string, value: string) => string
+export type FilterFieldConverter = (filterField: FilterField) => string[]
+
+export type BaseFilterBuilderFn = (
+  filters: Filter[],
+  filterField: FilterField,
+  ruleName: string,
+  transformValue: ValueTransformer,
+  buildItem: ItemBuilder,
+  filterFieldConverter: FilterFieldConverter
+) => string
+
+export type FilterBuilderFn = (filters: Filter[], filterField: FilterField, ruleName: string) => string

--- a/src/util/solr/filterBuilders/value.ts
+++ b/src/util/solr/filterBuilders/value.ts
@@ -1,0 +1,18 @@
+import { Filter } from '../../../models'
+import baseFilterBuilderFn, { defaultItemBuilder, noPrefixFilterFieldConverter } from './base'
+import { FilterBuilderFn, FilterField } from './types'
+
+export const escapeString = (s: string): string => s.replace(/[()\\+&|!{}[\]?:;,]/g, d => `\\${d}`)
+
+const valueBuilder: FilterBuilderFn = (filters: Filter[], filterField: FilterField, ruleName: string) => {
+  return baseFilterBuilderFn(
+    filters,
+    filterField,
+    ruleName,
+    escapeString,
+    defaultItemBuilder,
+    noPrefixFilterFieldConverter
+  )
+}
+
+export default valueBuilder

--- a/test/hooks/search.test.js
+++ b/test/hooks/search.test.js
@@ -1,9 +1,7 @@
-const assert = require('assert');
-const {
-  filtersToSolr,
-} = require('../../src/util/solr/filterReducers');
-const { filtersToSolrQuery, queries } = require('../../src/hooks/search');
-const { SolrNamespaces } = require('../../src/solr');
+const assert = require('assert')
+const { filtersToSolr } = require('../../src/util/solr/filterReducers')
+const { filtersToSolrQuery, queries } = require('../../src/hooks/search')
+const { SolrNamespaces } = require('../../src/solr')
 
 /*
 ./node_modules/.bin/eslint \
@@ -12,36 +10,51 @@ NODE_ENV=development mocha test/hooks/search.test.js
 */
 describe('test single reducers in search hook', () => {
   it('for language filters', () => {
-    const sq = filtersToSolr([
-      {
-        context: 'include',
-        type: 'language',
-        q: ['fr', 'en'],
-      },
-    ], SolrNamespaces.Search);
-    assert.deepEqual('(lg_s:fr OR lg_s:en)', sq);
-  });
+    const sq = filtersToSolr(
+      [
+        {
+          context: 'include',
+          type: 'language',
+          q: ['fr', 'en'],
+        },
+      ],
+      SolrNamespaces.Search
+    )
+    assert.deepEqual('(lg_s:fr OR lg_s:en)', sq)
+  })
 
   it('exclude language filters', () => {
-    const sq = filtersToSolr([
-      {
-        context: 'exclude',
-        type: 'language',
-        q: ['fr', 'en'],
-      },
-    ], SolrNamespaces.Search);
-    assert.deepEqual('*:* AND NOT ((lg_s:fr OR lg_s:en))', sq);
-  });
+    const sq = filtersToSolr(
+      [
+        {
+          context: 'exclude',
+          type: 'language',
+          q: ['fr', 'en'],
+        },
+      ],
+      SolrNamespaces.Search
+    )
+    // assert.deepEqual('*:* AND NOT ((lg_s:fr OR lg_s:en))', sq);
+    assert.deepEqual('NOT (lg_s:fr OR lg_s:en)', sq)
+  })
 
   it('test regex filter, multiple words', () => {
-    const sq = filtersToSolr([{
-      context: 'include',
-      type: 'regex',
-      q: '/go[uû]t.*parfait.*/',
-    }], SolrNamespaces.Search);
-    assert.deepEqual(sq, '(content_txt_en:/go[uû]t/ OR content_txt_fr:/go[uû]t/ OR content_txt_de:/go[uû]t/) AND (content_txt_en:/parfait/ OR content_txt_fr:/parfait/ OR content_txt_de:/parfait/)');
-  });
-});
+    const sq = filtersToSolr(
+      [
+        {
+          context: 'include',
+          type: 'regex',
+          q: '/go[uû]t.*parfait.*/',
+        },
+      ],
+      SolrNamespaces.Search
+    )
+    assert.deepEqual(
+      sq,
+      '(content_txt_en:/go[uû]t/ OR content_txt_fr:/go[uû]t/ OR content_txt_de:/go[uû]t/) AND (content_txt_en:/parfait/ OR content_txt_fr:/parfait/ OR content_txt_de:/parfait/)'
+    )
+  })
+})
 
 describe('test filtersToSolrQuery hook', () => {
   it('with two filters', async () => {
@@ -61,24 +74,29 @@ describe('test filtersToSolrQuery hook', () => {
               context: 'include',
               type: 'newspaper',
               q: ['GDL'],
-            }, {
+            },
+            {
               context: 'include',
               type: 'year',
               q: ['1957', '1958', '1954'],
-            }, {
+            },
+            {
               context: 'include',
               type: 'language',
-              q: ['french'],
+              q: ['fr'],
             },
           ],
         },
       },
-    };
-    await filtersToSolrQuery()(context);
+    }
+    await filtersToSolrQuery()(context)
     // console.log(context.params.sanitized);
-    assert.equal(context.params.sanitized.sq, '(content_txt_en:ambassad* OR content_txt_fr:ambassad* OR content_txt_de:ambassad*) AND filter((meta_journal_s:GDL)) AND filter((meta_year_i:1957 OR meta_year_i:1958 OR meta_year_i:1954)) AND filter((lg_s:french))');
+    assert.equal(
+      context.params.sanitized.sq,
+      '(content_txt_en:ambassad* OR content_txt_fr:ambassad* OR content_txt_de:ambassad*) AND filter(meta_journal_s:GDL) AND filter((meta_year_i:1957 OR meta_year_i:1958 OR meta_year_i:1954)) AND filter(lg_s:fr)'
+    )
     // console.log(context);
-  });
+  })
 
   it('with precision', async () => {
     const context = {
@@ -90,7 +108,7 @@ describe('test filtersToSolrQuery hook', () => {
               type: 'string',
               precision: 'fuzzy',
               context: 'include',
-              q: 'accident d\'avion',
+              q: "accident d'avion",
             },
             {
               type: 'string',
@@ -101,11 +119,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
-    await filtersToSolrQuery()(context);
+    }
+    await filtersToSolrQuery()(context)
 
-    assert.deepEqual(context.params.sanitized.sq, '(content_txt_en:"accident d\'avion"~1 OR content_txt_fr:"accident d\'avion"~1 OR content_txt_de:"accident d\'avion"~1) AND (content_txt_en:(ministre OR portugais) OR content_txt_fr:(ministre OR portugais) OR content_txt_de:(ministre OR portugais))');
-  });
+    assert.deepEqual(
+      context.params.sanitized.sq,
+      '(content_txt_en:"accident d\'avion"~1 OR content_txt_fr:"accident d\'avion"~1 OR content_txt_de:"accident d\'avion"~1) AND (content_txt_en:(ministre OR portugais) OR content_txt_fr:(ministre OR portugais) OR content_txt_de:(ministre OR portugais))'
+    )
+  })
 
   it('with text context', async () => {
     const context = {
@@ -128,14 +149,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
+    }
 
-    await filtersToSolrQuery()(context);
+    await filtersToSolrQuery()(context)
     assert.deepEqual(
       context.params.sanitized.sq,
-      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")`,
-    );
-  });
+      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")`
+    )
+  })
 
   it('with text context exact by quotes', async () => {
     const context = {
@@ -157,14 +178,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
+    }
 
-    await filtersToSolrQuery()(context);
+    await filtersToSolrQuery()(context)
     assert.deepEqual(
       context.params.sanitized.sq,
-      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")`,
-    );
-  });
+      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")`
+    )
+  })
 
   it('with text context, exaped wrong quotes', async () => {
     const context = {
@@ -186,14 +207,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
+    }
 
-    await filtersToSolrQuery()(context);
+    await filtersToSolrQuery()(context)
     assert.deepEqual(
       context.params.sanitized.sq,
-      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre \\"portugais" OR content_txt_fr:"ministre \\"portugais" OR content_txt_de:"ministre \\"portugais")`,
-    );
-  });
+      `filter(${queries.hasTextContents}) AND filter(front_b:1) AND (content_txt_en:"ministre \\"portugais" OR content_txt_fr:"ministre \\"portugais" OR content_txt_de:"ministre \\"portugais")`
+    )
+  })
 
   it('with text context, with multiple contents', async () => {
     const context = {
@@ -215,14 +236,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
+    }
 
-    await filtersToSolrQuery()(context);
+    await filtersToSolrQuery()(context)
     assert.deepEqual(
       context.params.sanitized.sq,
-      'filter(content_length_i:[1 TO *]) AND filter(front_b:1) AND ((content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais") OR (content_txt_en:"ministre italien" OR content_txt_fr:"ministre italien" OR content_txt_de:"ministre italien"))',
-    );
-  });
+      'filter(content_length_i:[1 TO *]) AND filter(front_b:1) AND ((content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais") OR (content_txt_en:"ministre italien" OR content_txt_fr:"ministre italien" OR content_txt_de:"ministre italien"))'
+    )
+  })
 
   it('with daterange filters', async () => {
     const context = {
@@ -245,14 +266,14 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
-    await filtersToSolrQuery()(context);
+    }
+    await filtersToSolrQuery()(context)
 
     assert.equal(
       context.params.sanitized.sq,
-      'filter(*:* AND NOT (meta_date_dt:[1952-01-01T00:00:00Z TO 1953-01-01T00:00:00Z]) AND meta_date_dt:[1950-01-01T00:00:00Z TO 1958-01-01T00:00:00Z])',
-    );
-  });
+      'filter(*:* AND NOT (meta_date_dt:[1952-01-01T00:00:00Z TO 1953-01-01T00:00:00Z]) AND meta_date_dt:[1950-01-01T00:00:00Z TO 1958-01-01T00:00:00Z])'
+    )
+  })
 
   it('with all possible filters', async () => {
     const context = {
@@ -268,10 +289,7 @@ describe('test filtersToSolrQuery hook', () => {
             {
               type: 'daterange',
               context: 'include',
-              q: [
-                '1950-01-01T00:00:00Z TO 1958-01-01T00:00:00Z',
-                '1945-01-01T00:00:00Z TO 1946-01-01T00:00:00Z',
-              ],
+              q: ['1950-01-01T00:00:00Z TO 1958-01-01T00:00:00Z', '1945-01-01T00:00:00Z TO 1946-01-01T00:00:00Z'],
             },
             {
               context: 'include',
@@ -284,14 +302,16 @@ describe('test filtersToSolrQuery hook', () => {
               context: 'include',
               type: 'newspaper',
               q: ['GDL'],
-            }, {
+            },
+            {
               context: 'include',
               type: 'year',
               q: ['1957', '1958', '1954'],
-            }, {
+            },
+            {
               context: 'include',
               type: 'language',
-              q: ['french', 'german'],
+              q: ['fr', 'de'],
             },
             {
               context: 'include',
@@ -301,18 +321,19 @@ describe('test filtersToSolrQuery hook', () => {
           ],
         },
       },
-    };
-    await filtersToSolrQuery()(context);
+    }
+    await filtersToSolrQuery()(context)
     assert.equal(
       context.params.sanitized.sq,
       [
         'filter(*:* AND NOT (meta_date_dt:[1952-01-01T00:00:00Z TO 1953-01-01T00:00:00Z])',
         ' AND (meta_date_dt:[1950-01-01T00:00:00Z TO 1958-01-01T00:00:00Z] OR meta_date_dt:[1945-01-01T00:00:00Z TO 1946-01-01T00:00:00Z]))',
         ' AND (content_txt_en:ambassad* OR content_txt_fr:ambassad* OR content_txt_de:ambassad*)',
-        ' AND filter((meta_journal_s:GDL))',
+        ' AND filter(meta_journal_s:GDL)',
         ' AND filter((meta_year_i:1957 OR meta_year_i:1958 OR meta_year_i:1954))',
-        ' AND filter((lg_s:french OR lg_s:german)) AND filter((item_type_s:ar))',
-      ].join(''),
-    );
-  });
-});
+        ' AND filter((lg_s:fr OR lg_s:de))',
+        ' AND filter(item_type_s:ar)',
+      ].join('')
+    )
+  })
+})

--- a/test/util/solr/reducers.test.js
+++ b/test/util/solr/reducers.test.js
@@ -1,104 +1,104 @@
-const assert = require('assert');
-const { SolrNamespaces } = require('../../../src/solr');
-const { filtersToSolr } = require('../../../src/util/solr/filterReducers');
-const { InvalidArgumentError } = require('../../../src/util/error');
+const assert = require('assert')
+const { SolrNamespaces } = require('../../../src/solr')
+const { filtersToSolr } = require('../../../src/util/solr/filterReducers')
+const { InvalidArgumentError } = require('../../../src/util/error')
 
 describe('filtersToSolr', () => {
   it('throws an error for an unknown filter type', () => {
     const filter = {
       type: 'booomooo',
       q: '',
-    };
+    }
     assert.throws(
       () => filtersToSolr([filter], SolrNamespaces.Search),
-      new InvalidArgumentError(`Unknown filter type "${filter.type}" in namespace "${SolrNamespaces.Search}"`),
-    );
-  });
+      new InvalidArgumentError(`Unknown filter type "${filter.type}" in namespace "${SolrNamespaces.Search}"`)
+    )
+  })
 
   it('handles "minLengthOne" filter', () => {
     const filter = {
       type: 'hasTextContents',
-    };
-    const query = filtersToSolr([filter], SolrNamespaces.Search);
-    assert.equal(query, 'content_length_i:[1 TO *]');
-  });
+    }
+    const query = filtersToSolr([filter], SolrNamespaces.Search)
+    assert.equal(query, 'content_length_i:[1 TO *]')
+  })
 
   describe('handles "numericRange" filter', () => {
     it('with string', () => {
       const filter = {
         q: '1 TO 10',
         type: 'ocrQuality',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'ocrqa_f:[1 TO 10]');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'ocrqa_f:[1 TO 10]')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['2', '20'],
         type: 'ocrQuality',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'ocrqa_f:[2 TO 20]');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'ocrqa_f:[2 TO 20]')
+    })
 
     it('throws an error with malformed string', () => {
       const filter = {
         q: 'foo bar',
         type: 'ocrQuality',
-      };
+      }
       assert.throws(
         () => filtersToSolr([filter], SolrNamespaces.Search),
-        new InvalidArgumentError(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`),
-      );
-    });
+        new InvalidArgumentError(`"numericRange" filter rule: unknown value encountered in "q": ${filter.q}`)
+      )
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'ocrQuality',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'ocrqa_f:*');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'ocrqa_f:*')
+    })
 
     it('with empty array', () => {
       const filter = {
         q: [],
         type: 'ocrQuality',
-      };
+      }
       assert.throws(
         () => filtersToSolr([filter], SolrNamespaces.Search),
-        new InvalidArgumentError(`"numericRange" filter rule: unknown values encountered in "q": ${filter.q}`),
-      );
-    });
-  });
+        new InvalidArgumentError(`"numericRange" filter rule: unknown values encountered in "q": ${filter.q}`)
+      )
+    })
+  })
 
   it('handles "boolean" filter', () => {
     const filter = {
       type: 'isFront',
-    };
-    const query = filtersToSolr([filter], SolrNamespaces.Search);
-    assert.equal(query, 'front_b:1');
-  });
+    }
+    const query = filtersToSolr([filter], SolrNamespaces.Search)
+    assert.equal(query, 'front_b:1')
+  })
 
   describe('handles "string" filter', () => {
     it('with string', () => {
       const filter = {
         q: 'moo',
         type: 'title',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:moo OR title_txt_fr:moo OR title_txt_de:moo)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:moo OR title_txt_fr:moo OR title_txt_de:moo)')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['foo'],
         type: 'title',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:foo OR title_txt_fr:foo OR title_txt_de:foo)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:foo OR title_txt_fr:foo OR title_txt_de:foo)')
+    })
 
     it('with text context exact by quotes', () => {
       /** @type {import('../../../src/models').Filter} */
@@ -106,10 +106,13 @@ describe('filtersToSolr', () => {
         type: 'string',
         context: 'include',
         q: '"ministre portugais"',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(
+        query,
+        '(content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais")'
+      )
+    })
 
     it('with text context escaped wrong quotes', () => {
       /** @type {import('../../../src/models').Filter} */
@@ -117,10 +120,13 @@ describe('filtersToSolr', () => {
         type: 'string',
         context: 'include',
         q: '"ministre "portugais"',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:"ministre \\"portugais" OR content_txt_fr:"ministre \\"portugais" OR content_txt_de:"ministre \\"portugais")');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(
+        query,
+        '(content_txt_en:"ministre \\"portugais" OR content_txt_fr:"ministre \\"portugais" OR content_txt_de:"ministre \\"portugais")'
+      )
+    })
 
     it('with text context with multiple content', () => {
       /** @type {import('../../../src/models').Filter} */
@@ -128,27 +134,30 @@ describe('filtersToSolr', () => {
         type: 'string',
         context: 'include',
         q: ['"ministre portugais"', '"ministre italien"'],
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '((content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais") OR (content_txt_en:"ministre italien" OR content_txt_fr:"ministre italien" OR content_txt_de:"ministre italien"))');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(
+        query,
+        '((content_txt_en:"ministre portugais" OR content_txt_fr:"ministre portugais" OR content_txt_de:"ministre portugais") OR (content_txt_en:"ministre italien" OR content_txt_fr:"ministre italien" OR content_txt_de:"ministre italien"))'
+      )
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'title',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)')
+    })
 
     it('with empty string', () => {
       const filter = {
         type: 'title',
         q: '',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)')
+    })
 
     it('with empty array', () => {
       /** @type {import('../../../src/models').Filter} */
@@ -157,10 +166,10 @@ describe('filtersToSolr', () => {
         op: 'OR',
         q: [],
         precision: 'exact',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)')
+    })
 
     it('with array of empty strings', () => {
       /** @type {import('../../../src/models').Filter} */
@@ -169,242 +178,278 @@ describe('filtersToSolr', () => {
         op: 'OR',
         q: ['', ''],
         precision: 'exact',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)');
-    });
-  });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(title_txt_en:* OR title_txt_fr:* OR title_txt_de:*)')
+    })
+  })
 
   describe('handles "dateRange" filter', () => {
     it('with string', () => {
       const filter = {
         q: '1918 TO 2018',
         type: 'daterange',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'meta_date_dt:[1918 TO 2018]');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'meta_date_dt:[1918 TO 2018]')
+    })
 
     it('with ISO dates string', () => {
       const filter = {
         q: '1857-01-01T00:00:00Z TO 2014-12-31T23:59:59',
         type: 'daterange',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'meta_date_dt:[1857-01-01T00:00:00Z TO 2014-12-31T23:59:59]');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'meta_date_dt:[1857-01-01T00:00:00Z TO 2014-12-31T23:59:59]')
+    })
 
     it('with ISO dates string in array', () => {
       const filter = {
         q: ['1857-01-01T00:00:00Z TO 2014-12-31T23:59:59'],
         type: 'daterange',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'meta_date_dt:[1857-01-01T00:00:00Z TO 2014-12-31T23:59:59]');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'meta_date_dt:[1857-01-01T00:00:00Z TO 2014-12-31T23:59:59]')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['1918', '2018'],
         type: 'daterange',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(meta_date_dt:[1918] OR meta_date_dt:[2018])');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(meta_date_dt:[1918] OR meta_date_dt:[2018])')
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'daterange',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'meta_date_dt:*');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'meta_date_dt:*')
+    })
 
     it('throws an error with malformed string', () => {
       const filter = {
         q: 'foo bar',
         type: 'daterange',
-      };
+      }
       assert.throws(
         () => filtersToSolr([filter], SolrNamespaces.Search),
-        new InvalidArgumentError(`"dateRange" filter rule: unknown value encountered in "q": ${filter.q}`),
-      );
-    });
+        new InvalidArgumentError(`"dateRange" filter rule: unknown value encountered in "q": ${filter.q}`)
+      )
+    })
 
     it('throws an error with empty array', () => {
       const filter = {
         q: [],
         type: 'daterange',
-      };
+      }
       assert.throws(
         () => filtersToSolr([filter], SolrNamespaces.Search),
-        new InvalidArgumentError(`"dateRange" filter rule: unknown values encountered in "q": ${filter.q}`),
-      );
-    });
-  });
+        new InvalidArgumentError(`"dateRange" filter rule: unknown values encountered in "q": ${filter.q}`)
+      )
+    })
+  })
 
   describe('handles "value" filter', () => {
     it('with string', () => {
       const filter = {
         q: 'en',
         type: 'language',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'lg_s:en');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'lg_s:en')
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'language',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'lg_s:*');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'lg_s:*')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['en', 'fr'],
         type: 'language',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(lg_s:en OR lg_s:fr)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(lg_s:en OR lg_s:fr)')
+    })
 
     it('with multiple fields', () => {
       const filter = {
         q: ['ab', 'cd'],
         type: 'mention',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(pers_mentions:ab OR loc_mentions:ab OR pers_mentions:cd OR loc_mentions:cd)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '((pers_mentions:ab OR loc_mentions:ab) OR (pers_mentions:cd OR loc_mentions:cd))')
+    })
+
+    it('with and/or fields', () => {
+      const filter = {
+        q: ['e-a', 'e-b'],
+        type: 'entity',
+        op: 'AND',
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(
+        query,
+        '((pers_entities_dpfs:e-a OR loc_entities_dpfs:e-a) AND (pers_entities_dpfs:e-b OR loc_entities_dpfs:e-b))'
+      )
+    })
 
     it('with empty array', () => {
       const filter = {
         q: [],
         type: 'mention',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(pers_mentions:* OR loc_mentions:*)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(pers_mentions:* OR loc_mentions:*)')
+    })
 
     it('with empty string', () => {
       const filter = {
         type: 'language',
         q: '',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, 'lg_s:*');
-    });
-  });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'lg_s:*')
+    })
+
+    it('negated single', () => {
+      const filter = {
+        type: 'language',
+        q: 'en',
+        context: 'exclude',
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'NOT lg_s:en')
+    })
+
+    it('negated double', () => {
+      const filter = {
+        type: 'language',
+        q: ['en', 'de'],
+        context: 'exclude',
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, 'NOT (lg_s:en OR lg_s:de)')
+    })
+  })
 
   describe('handles "regex" filter', () => {
     it('with string', () => {
       const filter = {
         q: 'moo',
         type: 'regex',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:/moo/ OR content_txt_fr:/moo/ OR content_txt_de:/moo/)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(content_txt_en:/moo/ OR content_txt_fr:/moo/ OR content_txt_de:/moo/)')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['foo'],
         type: 'regex',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:/foo/ OR content_txt_fr:/foo/ OR content_txt_de:/foo/)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(content_txt_en:/foo/ OR content_txt_fr:/foo/ OR content_txt_de:/foo/)')
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'regex',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)')
+    })
 
     it('with empty string', () => {
       const filter = {
         type: 'regex',
         q: '',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)')
+    })
 
     it('with empty array', () => {
       const filter = {
         q: [],
         type: 'regex',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Search);
-      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)');
-    });
-  });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Search)
+      assert.equal(query, '(content_txt_en:/.*/ OR content_txt_fr:/.*/ OR content_txt_de:/.*/)')
+    })
+  })
 
   describe('handles "capitalisedValue" filter', () => {
     it('with string', () => {
       const filter = {
         q: 'person',
         type: 'type',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, 't_s:Person');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, 't_s:Person')
+    })
 
     it('with array', () => {
       const filter = {
         q: ['person', 'location'],
         type: 'type',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, '(t_s:Person OR t_s:Location)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, '(t_s:Person OR t_s:Location)')
+    })
 
     it('with no value', () => {
       const filter = {
         type: 'type',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, 't_s:*');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, 't_s:*')
+    })
 
     it('with empty array', () => {
       const filter = {
         q: [],
         type: 'type',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, '(t_s:*)');
-    });
-  });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, 't_s:*')
+    })
+  })
 
   describe('handles "openEndedString" filter', () => {
     it('with string', () => {
       const filter = {
         q: 'Jacques Chira',
         type: 'string',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, '(entitySuggest:Jacques AND entitySuggest:Chira*)');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, '(entitySuggest:Jacques AND entitySuggest:Chira*)')
+    })
     it('with unigram', () => {
       const filter = {
         q: 'Jacques ',
         type: 'string',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, 'entitySuggest:Jacques*');
-    });
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(query, 'entitySuggest:Jacques*')
+    })
     it('with array', () => {
       const filter = {
         q: ['Jacques Chirac', 'Foo Bar'],
         type: 'string',
-      };
-      const query = filtersToSolr([filter], SolrNamespaces.Entities);
-      assert.equal(query, '((entitySuggest:Jacques AND entitySuggest:Chirac*) OR (entitySuggest:Foo AND entitySuggest:Bar*))');
-    });
-  });
-});
+      }
+      const query = filtersToSolr([filter], SolrNamespaces.Entities)
+      assert.equal(
+        query,
+        '((entitySuggest:Jacques AND entitySuggest:Chirac*) OR (entitySuggest:Foo AND entitySuggest:Bar*))'
+      )
+    })
+  })
+})


### PR DESCRIPTION
This fixes the following filters set which are supposed to produce the same results.

## Working filters

```
[
    {
        context: 'include',
        op: 'OR',
        type: 'person',
        q: 'aida-0001-50-Niels_Bohr'
    },
    {
        context: 'include',
        op: 'OR',
        type: 'person',
        q: 'aida-0001-50-Albert_Einstein'
    }
]
```

## Not working filters

```
[
  {
      "context": "include",
      "op": "AND",
      "type": "entity",
      "q": [
          "aida-0001-50-Niels_Bohr",
          "aida-0001-50-Albert_Einstein"
      ]
  }
]
```

I had to refactor the Solr filter builder code for the `value` filter builder because it was hard to follow. The new structure can be used in all other builders. We can make this change in another PR.