### PR TITLE
added two new filter fields: `dataDomain` and `copyright`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "graphology-pagerank": "^1.1.0",
         "helmet": "^3.21.1",
         "http-proxy-middleware": "^2.0.1",
-        "impresso-jscommons": "https://github.com/impresso/impresso-jscommons/tarball/v1.4.3",
+        "impresso-jscommons": "https://github.com/impresso/impresso-jscommons/tarball/v1.5.0",
         "json-bigint": "^1.0.0",
         "json2csv": "^4.3.3",
         "jsonpath-plus": "^10.0.1",
@@ -6994,9 +6994,9 @@
       }
     },
     "node_modules/impresso-jscommons": {
-      "version": "1.4.3",
-      "resolved": "https://github.com/impresso/impresso-jscommons/tarball/v1.4.3",
-      "integrity": "sha512-Kawk9rmZ6mSr5gKMWRZaeyIsfCrmv5ytD80BwlFSaYZzcMLPYs4f3EDMpcGKFXgGMupwwMIJSHXhQSikaY0hBA==",
+      "version": "1.5.0",
+      "resolved": "https://github.com/impresso/impresso-jscommons/tarball/v1.5.0",
+      "integrity": "sha512-bgho/EQ7w5U7yAhd07FtmGVRvY84Gy7d8Z51g7t/Y2+xbGv8dgtZlBvlX1uMpmAGHCPP4Xuyh9774pWYngR9Cg==",
       "dependencies": {
         "base64-js": "1.3.1",
         "case": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "graphology-pagerank": "^1.1.0",
     "helmet": "^3.21.1",
     "http-proxy-middleware": "^2.0.1",
-    "impresso-jscommons": "https://github.com/impresso/impresso-jscommons/tarball/v1.4.3",
+    "impresso-jscommons": "https://github.com/impresso/impresso-jscommons/tarball/v1.5.0",
     "json-bigint": "^1.0.0",
     "json2csv": "^4.3.3",
     "jsonpath-plus": "^10.0.1",

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -158,6 +158,10 @@ export const SolrMappings: Record<string, ISolrMappings> = Object.freeze({
         offset: 0,
         numBuckets: true,
       },
+      /**
+       * @deprecated removed in Impresso 2.0. New field: rights_data_domain_s
+       * https://github.com/impresso/impresso-middle-layer/issues/462
+       */
       accessRight: {
         type: 'terms',
         field: 'access_right_s',
@@ -169,6 +173,28 @@ export const SolrMappings: Record<string, ISolrMappings> = Object.freeze({
       partner: {
         type: 'terms',
         field: 'meta_partnerid_s',
+        mincount: 0,
+        limit: 10,
+        offset: 0,
+        numBuckets: true,
+      },
+      /**
+       * Available in Impresso 2.0 only.
+       */
+      dataDomain: {
+        type: 'terms',
+        field: 'rights_data_domain_s',
+        mincount: 0,
+        limit: 10,
+        offset: 0,
+        numBuckets: true,
+      },
+      /**
+       * Available in Impresso 2.0 only.
+       */
+      copyright: {
+        type: 'terms',
+        field: 'rights_copyright_s',
         mincount: 0,
         limit: 10,
         offset: 0,

--- a/src/models/articles.model.js
+++ b/src/models/articles.model.js
@@ -51,11 +51,14 @@ export const ARTICLE_SOLR_FL_LIST_ITEM = [
   'rc_plains',
   // snippet
   'snippet_plain',
-  'access_right_s',
   'meta_partnerid_s',
   // layout & quality
   'olr_b',
   // access & download
+  /**
+   * @deprecated removed in Impresso 2.0. New field: rights_data_domain_s
+   * https://github.com/impresso/impresso-middle-layer/issues/462
+   */
   'access_right_s',
   'exportable_plain',
   // permissions bitmaps
@@ -63,6 +66,8 @@ export const ARTICLE_SOLR_FL_LIST_ITEM = [
   'rights_bm_explore_l',
   'rights_bm_get_tr_l',
   'rights_bm_get_img_l',
+  'rights_data_domain_s',
+  'rights_copyright_s',
 ]
 
 export const ARTICLE_SOLR_FL_LITE = [
@@ -316,6 +321,8 @@ class Article extends BaseArticle {
     bitmapExplore = undefined,
     bitmapGetTranscript = undefined,
     bitmapGetImages = undefined,
+    dataDomain = undefined,
+    copyright = undefined,
   } = {}) {
     super({
       uid,
@@ -400,6 +407,9 @@ class Article extends BaseArticle {
     this.bitmapExplore = bitmapExplore
     this.bitmapGetTranscript = bitmapGetTranscript
     this.bitmapGetImages = bitmapGetImages
+
+    this.dataDomain = dataDomain
+    this.copyright = copyright
   }
 
   enrich(rc, lb, rb) {
@@ -718,6 +728,10 @@ class Article extends BaseArticle {
 
         rc,
         // accessRight
+        /**
+         * @deprecated removed in Impresso 2.0. New field: rights_data_domain_s
+         * https://github.com/impresso/impresso-middle-layer/issues/462
+         */
         accessRight: doc.access_right_s || ACCESS_RIGHT_NOT_SPECIFIED,
         mentions: typeof doc.nem_offset_plain === 'string' ? JSON.parse(doc.nem_offset_plain) : doc.nem_offset_plain,
         topics: ArticleTopic.solrDPFsFactory(doc.topics_dpfs),
@@ -730,6 +744,9 @@ class Article extends BaseArticle {
         bitmapExplore: BigInt(doc.rights_bm_explore_l ?? OpenPermissions),
         bitmapGetTranscript: BigInt(doc.rights_bm_get_tr_l ?? OpenPermissions),
         bitmapGetImages: BigInt(doc.rights_bm_get_img_l ?? OpenPermissions),
+
+        dataDomain: doc.rights_data_domain_s,
+        copyright: doc.rights_copyright_s,
       })
 
       if (!doc.pp_plain) {

--- a/src/models/generated/schemas.d.ts
+++ b/src/models/generated/schemas.d.ts
@@ -175,7 +175,18 @@ export interface ContentItem {
    * TODO
    */
   labels: "article"[];
-  accessRight: "na" | "OpenPrivate" | "Closed" | "OpenPublic";
+  /**
+   * The access rights of the content item. Available in Impresso 1.0 only
+   */
+  accessRight?: "na" | "OpenPrivate" | "Closed" | "OpenPublic";
+  /**
+   * The data domain of the content item ('pbl' for Public Domain, 'prt' for Protected Domain). Available in Impresso 2.0 only
+   */
+  dataDomain?: "pbl" | "prt";
+  /**
+   * Copyright of the content item. Available in Impresso 2.0 only. pbl: 'Public Domain', und: 'Protected Domain: Copyright undetermined', nkn: 'Protected Domain: No Known Copyright', euo: 'Protected Domain: In copyright - EU Orphan Work', unk: 'Protected Domain: In copyright - Unknown rightsholders', in_cpy: 'Protected Domain: In copyright'.
+   */
+  copyright?: "pbl" | "und" | "nkn" | "euo" | "unk" | "in_cpy";
   /**
    * TODO
    */

--- a/src/schema/schemas/ContentItem.json
+++ b/src/schema/schemas/ContentItem.json
@@ -85,7 +85,18 @@
     },
     "accessRight": {
       "type": "string",
-      "enum": ["na", "OpenPrivate", "Closed", "OpenPublic"]
+      "enum": ["na", "OpenPrivate", "Closed", "OpenPublic"],
+      "description": "The access rights of the content item. Available in Impresso 1.0 only"
+    },
+    "dataDomain": {
+      "type": "string",
+      "enum": ["pbl", "prt"],
+      "description": "The data domain of the content item ('pbl' for Public Domain, 'prt' for Protected Domain). Available in Impresso 2.0 only"
+    },
+    "copyright": {
+      "type": "string",
+      "enum": ["pbl", "und", "nkn", "euo", "unk", "in_cpy"],
+      "description": "Copyright of the content item. Available in Impresso 2.0 only. pbl: 'Public Domain', und: 'Protected Domain: Copyright undetermined', nkn: 'Protected Domain: No Known Copyright', euo: 'Protected Domain: In copyright - EU Orphan Work', unk: 'Protected Domain: In copyright - Unknown rightsholders', in_cpy: 'Protected Domain: In copyright'."
     },
     "isFront": {
       "type": "boolean",
@@ -173,5 +184,5 @@
       "description": "Access rights bitmap for getting images"
     }
   },
-  "required": ["uid", "type", "title", "size", "nbPages", "pages", "isCC", "excerpt", "labels", "accessRight", "year"]
+  "required": ["uid", "type", "title", "size", "nbPages", "pages", "isCC", "excerpt", "labels", "year"]
 }

--- a/src/transformers/searchFacet.ts
+++ b/src/transformers/searchFacet.ts
@@ -34,6 +34,8 @@ const transformBucket = (
     case 'type':
     case 'language':
     case 'accessRight':
+    case 'dataDomain':
+    case 'copyright':
       return {
         count: input.count,
         value: String(input.val),

--- a/src/util/solr/solrFilters.yml
+++ b/src/util/solr/solrFilters.yml
@@ -31,8 +31,18 @@ indexes:
       uid:
         field: id
         rule: value
+      # @deprecated removed in Impresso 2.0. New field: rights_data_domain_s
+      # https://github.com/impresso/impresso-middle-layer/issues/462
       accessRight:
         field: access_right_s
+        rule: value
+      # Impresso 2.0 only
+      dataDomain:
+        field: rights_data_domain_s
+        rule: value
+      # Impresso 2.0 only
+      copyright:
+        field: rights_copyright_s
         rule: value
       partner:
         field: meta_partnerid_s


### PR DESCRIPTION
Resolves https://github.com/impresso/impresso-middle-layer/issues/462
Requires a new version of [impresso-jscommons](https://github.com/impresso/impresso-jscommons): v1.5.0. Use this or older version to use the new fields in the web app.