### PR TITLE
support for configuration file variables expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint src/. --config .eslintrc.js",
     "lint-api-spec": "spectral lint http://localhost:3030/swagger.json ",
     "start": "node dist/",
-    "dev": "nodemon --enable-source-maps --inspect dist/ --ignore 'data/*'",
+    "dev": "nodemon --exec 'node --env-file=.env' --enable-source-maps --inspect dist/ --ignore 'data/*' --env-file ./.env",
     "cli": "node src/admin/cli.js",
     "generate-types": "node dist/scripts/generate-types.js",
     "update-years": "node dist/scripts/update-years.js",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,3 @@
-import { default as feathersConfiguration } from '@feathersjs/configuration'
 import { Ajv, getValidator } from '@feathersjs/schema'
 import { Cache } from './cache'
 import type { RedisClientOptions } from 'redis'
@@ -8,6 +7,7 @@ import { Sequelize } from 'sequelize'
 import { CeleryClient } from './celery'
 import type { CeleryConfig, Config, RedisConfig, SolrServerProxy } from './models/generated/common'
 import { ImpressoApplication } from './types'
+import { feathersConfigurationLoader } from './util/configuration'
 
 const ajv = new Ajv()
 const configurationSchema = require('./schema/common/config.json')
@@ -36,5 +36,5 @@ export interface Configuration extends Config {
 const configurationValidator = getValidator(configurationSchema, ajv)
 
 export default function configuration(app: ImpressoApplication) {
-  return app.configure(feathersConfiguration(configurationValidator))
+  return app.configure(feathersConfigurationLoader(configurationValidator))
 }

--- a/src/util/configuration.ts
+++ b/src/util/configuration.ts
@@ -1,0 +1,168 @@
+import { Application, ApplicationHookContext, NextFunction } from '@feathersjs/feathers'
+import { Schema, Validator } from '@feathersjs/schema'
+import config from 'config'
+
+/**
+ * Recursively traverses an object (including arrays and nested objects) and replaces
+ * any string values matching the pattern `${VARIABLE_NAME}` with the corresponding
+ * environment variable value.
+ *
+ * @param obj - The object to process (can be an object, array, or primitive value)
+ * @param envVars - Optional environment variables object (defaults to process.env)
+ * @returns A new object with environment variable substitutions applied
+ *
+ * @example
+ * ```typescript
+ * const config = {
+ *   database: {
+ *     host: '${DB_HOST}',
+ *     port: '${DB_PORT}',
+ *     credentials: ['${DB_USER}', '${DB_PASS}']
+ *   },
+ *   features: ['${FEATURE_A}', 'static-feature']
+ * }
+ *
+ * // With environment variables: DB_HOST=localhost, DB_PORT=5432, DB_USER=admin, DB_PASS=secret, FEATURE_A=advanced
+ * const result = replaceEnvVariables(config)
+ * // Returns:
+ * // {
+ * //   database: {
+ * //     host: 'localhost',
+ * //     port: '5432',
+ * //     credentials: ['admin', 'secret']
+ * //   },
+ * //   features: ['advanced', 'static-feature']
+ * // }
+ * ```
+ */
+export function replaceEnvVariables<T>(obj: T, envVars: Record<string, string | undefined> = process.env): T {
+  if (obj === null || obj === undefined) {
+    return obj
+  }
+
+  // Handle primitive types
+  if (typeof obj !== 'object') {
+    if (typeof obj === 'string') {
+      return replaceEnvVariable(obj, envVars) as T
+    }
+    return obj
+  }
+
+  // Handle arrays
+  if (Array.isArray(obj)) {
+    return obj.map(item => replaceEnvVariables(item, envVars)) as T
+  }
+
+  // Handle objects
+  const result = {} as T
+  for (const [key, value] of Object.entries(obj)) {
+    ;(result as any)[key] = replaceEnvVariables(value, envVars)
+  }
+
+  return result
+}
+
+/**
+ * Replaces a single string value if it matches the `${VARIABLE_NAME}` pattern.
+ *
+ * @param value - The string value to check and potentially replace
+ * @param envVars - Environment variables object
+ * @returns The original value or the environment variable value if pattern matches
+ */
+function replaceEnvVariable(value: string, envVars: Record<string, string | undefined>): string {
+  // Match the pattern ${VARIABLE_NAME}
+  const envVarPattern = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/
+  const match = value.match(envVarPattern)
+
+  if (match) {
+    const varName = match[1]
+    const envValue = envVars[varName]
+
+    if (envValue !== undefined) {
+      return envValue
+    }
+
+    // If the variable is not found, raise an error
+    throw new Error(`Environment variable ${varName} is not defined`)
+
+    // // If environment variable is not found, return the original value
+    // // This allows for graceful fallback behavior
+    // return value
+  }
+
+  return value
+}
+
+/**
+ * Replaces environment variables in a configuration object and validates
+ * that all required environment variables are present.
+ *
+ * @param obj - The object to process
+ * @param requiredVars - Array of environment variable names that must be present
+ * @param envVars - Optional environment variables object (defaults to process.env)
+ * @returns A new object with environment variable substitutions applied
+ * @throws Error if any required environment variables are missing
+ *
+ * @example
+ * ```typescript
+ * const config = {
+ *   database: {
+ *     host: '${DB_HOST}',
+ *     port: '${DB_PORT}'
+ *   }
+ * }
+ *
+ * const result = replaceEnvVariablesStrict(config, ['DB_HOST', 'DB_PORT'])
+ * // Throws an error if DB_HOST or DB_PORT are not set in environment
+ * ```
+ */
+export function replaceEnvVariablesStrict<T>(
+  obj: T,
+  requiredVars: string[],
+  envVars: Record<string, string | undefined> = process.env
+): T {
+  // Check that all required environment variables are present
+  const missingVars = requiredVars.filter(varName => envVars[varName] === undefined)
+
+  if (missingVars.length > 0) {
+    throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`)
+  }
+
+  return replaceEnvVariables(obj, envVars)
+}
+
+/**
+ * A drop-in replacement for `@feathersjs/configuration` that loads configuration
+ * from a JSON file and applies environment variable substitutions.
+ *
+ * https://github.com/feathersjs/feathers/blob/dove/packages/configuration/src/index.ts
+ */
+export function feathersConfigurationLoader(schema?: Schema<any> | Validator) {
+  const validator = typeof schema === 'function' ? schema : schema?.validate.bind(schema)
+
+  return (app?: Application) => {
+    if (!app) {
+      return replaceEnvVariables(config)
+    }
+
+    const configuration: { [key: string]: unknown } = replaceEnvVariables({ ...config })
+
+    Object.keys(configuration).forEach(name => {
+      const value = configuration[name]
+      app.set(name, value)
+    })
+
+    if (validator) {
+      app.hooks({
+        setup: [
+          async (_context: ApplicationHookContext, next: NextFunction) => {
+            await validator(configuration)
+            await next()
+          },
+        ],
+      })
+    }
+
+    return config
+  }
+}

--- a/test/util/configuration.test.ts
+++ b/test/util/configuration.test.ts
@@ -1,0 +1,323 @@
+import assert from 'assert'
+import { replaceEnvVariables, replaceEnvVariablesStrict } from '../../src/util/configuration'
+
+describe('Environment Variable Configuration Utils', () => {
+  describe('replaceEnvVariables', () => {
+    it('should replace simple string environment variables', () => {
+      const input = '${TEST_VAR}'
+      const envVars = { TEST_VAR: 'test_value' }
+
+      const result = replaceEnvVariables(input, envVars)
+
+      assert.strictEqual(result, 'test_value')
+    })
+
+    it('should throw an error when environment variable is not found', () => {
+      const input = '${MISSING_VAR}'
+      const envVars = {}
+
+      assert.throws(() => replaceEnvVariables(input, envVars), {
+        message: 'Environment variable MISSING_VAR is not defined',
+      })
+    })
+
+    it('should not replace strings that do not match the exact pattern', () => {
+      const envVars = { TEST_VAR: 'test_value' }
+
+      const testCases = [
+        'prefix_${TEST_VAR}',
+        '${TEST_VAR}_suffix',
+        'prefix_${TEST_VAR}_suffix',
+        '$TEST_VAR',
+        '${TEST_VAR',
+        'TEST_VAR}',
+        '${TEST-VAR}', // hyphens not allowed
+        '${123VAR}', // numbers at start not allowed
+        '${}', // empty variable name
+      ]
+
+      testCases.forEach(testCase => {
+        const result = replaceEnvVariables(testCase, envVars)
+        assert.strictEqual(result, testCase, `Should not replace: ${testCase}`)
+      })
+    })
+
+    it('should handle primitive types correctly', () => {
+      const envVars = { TEST_VAR: 'test_value' }
+
+      assert.strictEqual(replaceEnvVariables(42, envVars), 42)
+      assert.strictEqual(replaceEnvVariables(true, envVars), true)
+      assert.strictEqual(replaceEnvVariables(null, envVars), null)
+      assert.strictEqual(replaceEnvVariables(undefined, envVars), undefined)
+    })
+
+    it('should replace environment variables in nested objects', () => {
+      const input = {
+        database: {
+          host: '${DB_HOST}',
+          port: '${DB_PORT}',
+          config: {
+            ssl: '${DB_SSL}',
+            timeout: 5000,
+          },
+        },
+        api: {
+          key: '${API_KEY}',
+        },
+        staticValue: 'unchanged',
+      }
+
+      const envVars = {
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        DB_SSL: 'true',
+        API_KEY: 'secret123',
+      }
+
+      const result = replaceEnvVariables(input, envVars)
+
+      const expected = {
+        database: {
+          host: 'localhost',
+          port: '5432',
+          config: {
+            ssl: 'true',
+            timeout: 5000,
+          },
+        },
+        api: {
+          key: 'secret123',
+        },
+        staticValue: 'unchanged',
+      }
+
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('should replace environment variables in arrays', () => {
+      const input = [
+        '${VAR_1}',
+        '${VAR_2}',
+        'static_value',
+        42,
+        {
+          nested: '${VAR_3}',
+          array: ['${VAR_4}', 'static'],
+        },
+      ]
+
+      const envVars = {
+        VAR_1: 'value1',
+        VAR_2: 'value2',
+        VAR_3: 'value3',
+        VAR_4: 'value4',
+      }
+
+      const result = replaceEnvVariables(input, envVars)
+
+      const expected = [
+        'value1',
+        'value2',
+        'static_value',
+        42,
+        {
+          nested: 'value3',
+          array: ['value4', 'static'],
+        },
+      ]
+
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('should handle complex nested structures', () => {
+      const input = {
+        services: [
+          {
+            name: 'database',
+            config: {
+              host: '${DB_HOST}',
+              credentials: ['${DB_USER}', '${DB_PASS}'],
+            },
+          },
+          {
+            name: 'cache',
+            config: {
+              redis: {
+                url: '${REDIS_URL}',
+                options: {
+                  retryDelayOnFailover: 100,
+                  enableReadyCheck: '${REDIS_READY_CHECK}',
+                },
+              },
+            },
+          },
+        ],
+        features: {
+          enabled: ['${FEATURE_A}', '${FEATURE_B}'],
+          disabled: ['feature_c'],
+        },
+      }
+
+      const envVars = {
+        DB_HOST: 'db.example.com',
+        DB_USER: 'admin',
+        DB_PASS: 'secret123',
+        REDIS_URL: 'redis://localhost:6379',
+        REDIS_READY_CHECK: 'true',
+        FEATURE_A: 'analytics',
+        FEATURE_B: 'monitoring',
+      }
+
+      const result = replaceEnvVariables(input, envVars)
+
+      assert.strictEqual((result as any).services[0].config.host, 'db.example.com')
+      assert.deepStrictEqual((result as any).services[0].config.credentials, ['admin', 'secret123'])
+      assert.strictEqual((result as any).services[1].config.redis.url, 'redis://localhost:6379')
+      assert.strictEqual((result as any).services[1].config.redis.options.enableReadyCheck, 'true')
+      assert.strictEqual((result as any).services[1].config.redis.options.retryDelayOnFailover, 100)
+      assert.deepStrictEqual((result as any).features.enabled, ['analytics', 'monitoring'])
+      assert.deepStrictEqual((result as any).features.disabled, ['feature_c'])
+    })
+
+    it('should use process.env by default', () => {
+      // Set a test environment variable
+      const originalValue = process.env.TEST_ENV_VAR
+      process.env.TEST_ENV_VAR = 'from_process_env'
+
+      try {
+        const input = { test: '${TEST_ENV_VAR}' }
+        const result = replaceEnvVariables(input)
+
+        assert.strictEqual(result.test, 'from_process_env')
+      } finally {
+        // Clean up
+        if (originalValue !== undefined) {
+          process.env.TEST_ENV_VAR = originalValue
+        } else {
+          delete process.env.TEST_ENV_VAR
+        }
+      }
+    })
+
+    it('should handle empty objects and arrays', () => {
+      const envVars = { TEST_VAR: 'test_value' }
+
+      assert.deepStrictEqual(replaceEnvVariables({}, envVars), {})
+      assert.deepStrictEqual(replaceEnvVariables([], envVars), [])
+    })
+
+    it('should not mutate the original object', () => {
+      const input = {
+        config: {
+          value: '${TEST_VAR}',
+        },
+      }
+      const envVars = { TEST_VAR: 'new_value' }
+
+      const result = replaceEnvVariables(input, envVars)
+
+      // Original should be unchanged
+      assert.strictEqual(input.config.value, '${TEST_VAR}')
+      // Result should be changed
+      assert.strictEqual(result.config.value, 'new_value')
+    })
+  })
+
+  describe('replaceEnvVariablesStrict', () => {
+    it('should successfully replace variables when all required vars are present', () => {
+      const input = {
+        database: {
+          host: '${DB_HOST}',
+          port: '${DB_PORT}',
+        },
+      }
+
+      const envVars = {
+        DB_HOST: 'localhost',
+        DB_PORT: '5432',
+        EXTRA_VAR: 'not_required',
+      }
+
+      const result = replaceEnvVariablesStrict(input, ['DB_HOST', 'DB_PORT'], envVars)
+
+      assert.strictEqual(result.database.host, 'localhost')
+      assert.strictEqual(result.database.port, '5432')
+    })
+
+    it('should throw error when required environment variables are missing', () => {
+      const input = {
+        database: {
+          host: '${DB_HOST}',
+          port: '${DB_PORT}',
+        },
+      }
+
+      const envVars = {
+        DB_HOST: 'localhost',
+        // DB_PORT is missing
+      }
+
+      assert.throws(
+        () => replaceEnvVariablesStrict(input, ['DB_HOST', 'DB_PORT'], envVars),
+        /Missing required environment variables: DB_PORT/
+      )
+    })
+
+    it('should throw error with multiple missing variables', () => {
+      const input = {
+        config: {
+          a: '${VAR_A}',
+          b: '${VAR_B}',
+          c: '${VAR_C}',
+        },
+      }
+
+      const envVars = {
+        VAR_B: 'value_b',
+      }
+
+      assert.throws(
+        () => replaceEnvVariablesStrict(input, ['VAR_A', 'VAR_B', 'VAR_C'], envVars),
+        /Missing required environment variables: VAR_A, VAR_C/
+      )
+    })
+
+    it('should throw with empty required variables array', () => {
+      const input = { test: '${TEST_VAR}' }
+      const envVars = {}
+
+      assert.throws(() => replaceEnvVariablesStrict(input, [], envVars), /Environment variable TEST_VAR is not defined/)
+    })
+
+    it('should use process.env by default for strict mode', () => {
+      const originalValues = {
+        STRICT_TEST_VAR_1: process.env.STRICT_TEST_VAR_1,
+        STRICT_TEST_VAR_2: process.env.STRICT_TEST_VAR_2,
+      }
+
+      process.env.STRICT_TEST_VAR_1 = 'value1'
+      process.env.STRICT_TEST_VAR_2 = 'value2'
+
+      try {
+        const input = {
+          var1: '${STRICT_TEST_VAR_1}',
+          var2: '${STRICT_TEST_VAR_2}',
+        }
+
+        const result = replaceEnvVariablesStrict(input, ['STRICT_TEST_VAR_1', 'STRICT_TEST_VAR_2'])
+
+        assert.strictEqual(result.var1, 'value1')
+        assert.strictEqual(result.var2, 'value2')
+      } finally {
+        // Clean up
+        for (const [key, value] of Object.entries(originalValues)) {
+          if (value !== undefined) {
+            process.env[key] = value
+          } else {
+            delete process.env[key]
+          }
+        }
+      }
+    })
+  })
+})


### PR DESCRIPTION
Adds support to environment variables expansion in the config:

Config:

```json
{
  "db_password": "${DB_PASS}"
}
```

`.env`:

```
DB_PASS=secret
```

Loaded config:

```json
{
  "db_password": "secret"
}
```