### PR TITLE
Solr Fields Content Item Documents - JSON schemas grouped by categories

### DIFF
--- a/src/schema/solr/ContentItemFields_access-rights.json
+++ b/src/schema/solr/ContentItemFields_access-rights.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for access right information of media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "rights_data_domain_s": {
+            "type": "string",
+            "description": "Rights data domain.",
+            "nullable": true
+        },
+        "rights_copyright_s": {
+            "type": "string",
+            "description": "Copyright status.",
+            "nullable": true
+        },
+        "rights_perm_use_explore_plain": {
+            "type": "string",
+            "description": "Permission for use in exploration.",
+            "nullable": true
+        },
+        "rights_perm_use_get_tr_plain": {
+            "type": "string",
+            "description": "Permission for use in text retrieval.",
+            "nullable": true
+        },
+        "rights_perm_use_get_img_plain": {
+            "type": "string",
+            "description": "Permission for use in image retrieval.",
+            "nullable": true
+        },
+        "rights_bm_explore_l": {
+            "type": "integer",
+            "description": "Bookmark limit for exploration.",
+            "nullable": true
+        },
+        "rights_bm_get_tr_l": {
+            "type": "integer",
+            "description": "Bookmark limit for text retrieval.",
+            "nullable": true
+        },
+        "rights_bm_get_img_l": {
+            "type": "integer",
+            "description": "Bookmark limit for image retrieval.",
+            "nullable": true
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "rights_data_domain_s",
+        "rights_copyright_s",
+        "rights_perm_use_explore_plain",
+        "rights_perm_use_get_tr_plain",
+        "rights_perm_use_get_img_plain",
+        "rights_bm_explore_l",
+        "rights_bm_get_tr_l",
+        "rights_bm_get_img_l"
+    ]
+}

--- a/src/schema/solr/ContentItemFields_audio-support.json
+++ b/src/schema/solr/ContentItemFields_audio-support.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for image related information for (digitised paper) media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "record_id_ss": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "Array of record identifiers for radio broadcast segments"
+        },
+        "record_nb_is": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            },
+            "description": "Array of record numbers corresponding to radio broadcast segments"
+        },
+        "nb_record_i": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total number of records/segments in the radio broadcast"
+        },
+        "rreb_plain": {
+            "type": "string",
+            "minimum": 0,
+            "description": "Audio time stamps of the audio record. Serialized JSON of radio broadcast segments as defined in https://github.com/impresso/impresso-schemas/blob/radio-broadcast-schemas/json/rebuilt/audio_record_contentitem.schema.json."
+        },
+        "additionalProperties": false
+    }
+}

--- a/src/schema/solr/ContentItemFields_contextual-metadata.json
+++ b/src/schema/solr/ContentItemFields_contextual-metadata.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for contextual metadata field of media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "meta_country_code_s": {
+            "type": "string",
+            "description": "Country code of the publication.",
+            "nullable": true
+        },
+        "meta_province_code_s": {
+            "type": "string",
+            "description": "Province code of the publication.",
+            "nullable": true
+        },
+        "meta_periodicity_s": {
+            "type": "string",
+            "description": "Periodicity of the publication, e.g., daily, weekly.",
+            "nullable": true
+        },
+        "meta_topics_s": {
+            "type": "string",
+            "description": "Topics associated with the publication.",
+            "nullable": true
+        },
+        "meta_polorient_s": {
+            "type": "string",
+            "description": "Political orientation of the publication.",
+            "nullable": true
+        },
+        "meta_partnerid_s": {
+            "type": "string",
+            "description": "Partner ID associated with the publication.",
+            "nullable": true
+        },
+        "additionalProperties": false
+    }
+}

--- a/src/schema/solr/ContentItemFields_core.json
+++ b/src/schema/solr/ContentItemFields_core.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for core fields of media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string",
+            "description": "Unique identifier for the content item"
+        },
+        "meta_journal_s": {
+            "type": "string",
+            "description": "Media title alias. Will soon be deprecated in favor of meta_media_s."
+        },
+        "meta_year_i": {
+            "type": "integer",
+            "description": "Year of publication/broadcast"
+        },
+        "meta_month_i": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 12,
+            "description": "Month of publication/broadcast"
+        },
+        "meta_yearmonth_s": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}$",
+            "description": "Year-month in YYYY-MM format"
+        },
+        "meta_day_i": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 31,
+            "description": "Day of publication/broadcast"
+        },
+        "meta_ed_s": {
+            "type": "string",
+            "description": "Edition identifier"
+        },
+        "meta_date_dt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Full date and time in ISO 8601 format"
+        },
+        "meta_issue_id_s": {
+            "type": "string",
+            "description": "Issue identifier"
+        },
+        "meta_source_type_s": {
+            "type": "string",
+            "enum": [
+                "newspaper",
+                "radio_broadcast",
+                "radio_magazine",
+                "radio_schedule",
+                "monograph",
+                "encyclopedia"
+            ],
+            "description": "Type of the media source. Should be a value from impresso-essentials.utils SourceType enum.",
+            "nullable": true
+        },
+        "meta_source_medium_s": {
+            "type": "string",
+            "description": "Medium of the source (audio for audio radio broadcasts, print for newspapers, typescript for digitised radio bulletin typescripts).",
+            "enum": [
+                "audio",
+                "print",
+                "typescript"
+            ],
+            "nullable": true
+        }
+    },
+    "meta_start_time_s": {
+        "type": "string",
+        "pattern": "^\\d{2}:\\d{2}:\\d{2}$",
+        "description": "Start time of media in HH:MM:SS format (relative to the day of broadcast). Applies only to audio radio broadcasts."
+    },
+    "meta_duration_s": {
+        "type": "string",
+        "pattern": "^\\d{2}:\\d{2}:\\d{2}$",
+        "description": "Duration of the radio broadcast in HH:MM:SS format (relative to the start of the broadcast on the given broadcast day).  Applies only to audio radio broadcasts.\""
+    },
+    "required": [
+        "id",
+        "meta_journal_s",
+        "meta_year_i",
+        "meta_month_i",
+        "meta_day_i",
+        "meta_date_dt"
+    ],
+    "dependentRequired": {
+        "meta_source_medium_s": [
+            "meta_source_type_s"
+        ],
+        "meta_source_type_s": [
+            "meta_source_medium_s"
+        ]
+    },
+    "if": {
+        "properties": {
+            "meta_source_medium_s": {
+                "const": "audio"
+            }
+        }
+    },
+    "then": {
+        "required": [
+            "meta_start_time_s",
+            "meta_duration_s"
+        ]
+    },
+    "additionalProperties": false
+}

--- a/src/schema/solr/ContentItemFields_image-support.json
+++ b/src/schema/solr/ContentItemFields_image-support.json
@@ -1,0 +1,78 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for image related information for (digitised paper) media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "page_id_ss": {
+            "type": "array",
+            "description": "List of page IDs associated with the content item.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "page_nb_is": {
+            "type": "array",
+            "description": "List of page numbers the content item appears on.",
+            "items": {
+                "type": "integer"
+            },
+            "nullable": true
+        },
+        "nb_pages_i": {
+            "type": "integer",
+            "description": "Total number of pages the content item is on.",
+            "nullable": true
+        },
+        "front_b": {
+            "type": "boolean",
+            "description": "Indicates if the CI is on the front page.",
+            "nullable": true
+        },
+        "reading_order_i": {
+            "type": "integer",
+            "description": "Reading order index of the content item, for the issue table of content.",
+            "nullable": true
+        },
+        "olr_b": {
+            "type": "boolean",
+            "description": "Indicates if the original digitised document has optical layout recognition (OLR).",
+            "nullable": true
+        },
+        "pp_plain": {
+            "type": "string",
+            "description": "Serialized JSON of page information.",
+            "nullable": true
+        },
+        "rc_plains": {
+            "type": "array",
+            "description": "List of region coordinates in stringified JSON format.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "lb_plain": {
+            "type": "string",
+            "description": "Serialized JSON of line breaks (relative to textual content).",
+            "nullable": true
+        },
+        "pb_plain": {
+            "type": "string",
+            "description": "Serialized JSON of paragraph breaks (relative to textual content).",
+            "nullable": true
+        },
+        "rb_plain": {
+            "type": "string",
+            "description": "Serialized JSON of region breaks (relative to textual content).",
+            "nullable": true
+        },
+        "cc_b": {
+            "type": "boolean",
+            "description": "Indicates whether coordinates were converted.",
+            "nullable": true
+        },
+        "additionalProperties": false
+    }
+}

--- a/src/schema/solr/ContentItemFields_sem-enrichments.json
+++ b/src/schema/solr/ContentItemFields_sem-enrichments.json
@@ -1,0 +1,150 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for semantic enrichments of media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "ocrqa_f": {
+            "type": "number",
+            "description": "OCR quality assessment score between 0,00 and 1,00.",
+            "nullable": true
+        },
+        "nag_mentions": {
+            "type": "array",
+            "description": "List of mentions from news agencies.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "nag_offset_plain": {
+            "type": "array",
+            "description": "Offsets for news agency mentions in plain text.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "nag_mention_conf_dpfs": {
+            "type": "array",
+            "description": "Confidence scores for news agency mentions.",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "nag_entities_dpfs": {
+            "type": "array",
+            "description": "Entities of type news agency.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "pers_mentions": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "pers_mention_conf_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "pers_entities_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "loc_mentions": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "loc_mention_conf_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "loc_entities_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "org_mentions": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "org_mention_conf_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "org_entities_dpfs": {
+            "type": "array",
+            "description": "",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "nem_offset_plain": {
+            "type": "array",
+            "description": "Offsets for named entity mentions in plain text.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "topics_dpfs": {
+            "type": "array",
+            "description": "Topics assigned to the content item.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "cluster_id_ss": {
+            "type": "array",
+            "description": "TR Cluster IDs assigned to the content item.",
+            "items": {
+                "type": "string"
+            },
+            "nullable": true
+        },
+        "gte_multi_v768": {
+            "type": "array",
+            "description": "Content item embedding as a vector of floats.",
+            "items": {
+                "type": "number"
+            },
+            "nullable": true
+        },
+        "additionalProperties": false
+    }
+}

--- a/src/schema/solr/ContentItemFields_text-content.json
+++ b/src/schema/solr/ContentItemFields_text-content.json
@@ -1,0 +1,79 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ContentItem",
+    "description": "Schema for textual content and content types fields of media content items in the Impresso project.",
+    "type": "object",
+    "properties": {
+        "doc_type_s": {
+            "type": "string",
+            "description": "Type of document, e.g., page (p) or content item (ci).",
+            "enum": [
+                "p",
+                "ci"
+            ],
+            "nullable": false
+        },
+        "item_type_s": {
+            "type": "string",
+            "enum": [
+                "ar",
+                "ad",
+                "page",
+                "tb",
+                "ob",
+                "w",
+                "chapter",
+                "chronicle",
+                "unsegmented",
+                "radio_broadcast_episode",
+                "radio_bulletin"
+            ],
+            "description": "Type of content item, e.g., article, section.",
+            "nullable": true
+        },
+        "lg_orig_s": {
+            "type": "string",
+            "description": "Original language of the content item.",
+            "nullable": true
+        },
+        "lg_s": {
+            "type": "string",
+            "description": "Computed language of the content item.",
+            "nullable": true
+        },
+        "patternProperties": {
+            "^title_txt_[a-z]{2}$": {
+                "type": "string",
+                "description": "Title of the article in the specified language (ISO 639-1 two-letter language code)"
+            },
+            "^content_txt_[a-z]{2}$": {
+                "type": "string",
+                "description": "Full text content of the article in the specified language (ISO 639-1 two-letter language code)",
+                "nullable": false
+            }
+        },
+        "content_length_i": {
+            "type": "integer",
+            "description": "Token count of the content item (space split).",
+            "nullable": true
+        },
+        "snippet_plain": {
+            "type": "string",
+            "description": "Snippet of the content item (first 150 characters).",
+            "nullable": true
+        },
+        "anyOf": [
+            {
+                "required": [
+                    "content_txt_en"
+                ]
+            },
+            {
+                "required": [
+                    "content_txt_fr"
+                ]
+            }
+        ],
+        "additionalProperties": false
+    }
+}


### PR DESCRIPTION
### Solr Fields Content Item Documents - JSON schemas grouped by categories

Additional information [here](https://docs.google.com/spreadsheets/d/1MA_ME3X1xH5e_VGJ8eTn8mBG1LgynRvAl9J_siEcOKM/edit?gid=484301303#gid=484301303) (2d tab).

A few comments:
- The grouping can be changed according to needs. In Solr, Content Items are one type of (solr) document.
- The fields `meta_source_type_s` and `meta_source_medium_s` are currently not required in the 'Core' group, but they should. This is to accommodate the fact that they currently may not exist.
- Some dependencies cannot be expressed because of the separation into groups, e.g. audio fields are present only if `meta_source_medium_s` is audio.
- On the long run, the field names in solr could be prefixed by their 'group'.
- The Image schema has been renamed to match the file naming convention of the Ci ones, but content was not touched.
- Files are all new, did not touch the original ones.