### PR TITLE
Update create method to use sfq query array to handle collection change

### DIFF
--- a/src/services/search-exporter/search-exporter.class.ts
+++ b/src/services/search-exporter/search-exporter.class.ts
@@ -39,7 +39,7 @@ export class Service {
       return {}
     }
 
-    const q = params.query.sfq.join(' AND ')
+    const q = params.query.sfq.map(term => `(${term})`).join(' AND ')
     debug('[create] from solr query:', q, 'filters:', params.sanitized.filters)
 
     const pq = protobuf.searchQuery.serialize({


### PR DESCRIPTION
The create method now expects params.query.sfq as an array of strings and joins them with 'AND' to form the query.