### PR TITLE
Move transformBaseFind earlier in find hooks

### DIFF
--- a/src/services/content-items/content-items.hooks.ts
+++ b/src/services/content-items/content-items.hooks.ts
@@ -155,9 +155,10 @@ export default {
   after: {
     find: [
       displayQueryParams(['filters']),
+      transformResponse(transformBaseFind),
+
       ...inPublicApiOrWhen(
         [
-          transformResponse(transformBaseFind),
           redactResponseDataItem(contentItemBlanketRedactionPolicyPublicApi),
           // NOTE: Do not check quota in find - transcript is not included
           redactResponseDataItem(


### PR DESCRIPTION
Apply transformResponse(transformBaseFind) before the inPublicApiOrWhen block for the find hook and remove the duplicate inside the block. This ensures the base transformation runs for all find responses up-front and avoids redundant/incorrect ordering with subsequent redaction and public-api-specific hooks.